### PR TITLE
TASK-7363	Migration Center 7.9 Release

### DIFF
--- a/Manuals/Tools/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/kor/Migration Center User's Manual.md
@@ -340,15 +340,15 @@ Migration Center는 데이터베이스 사이에 일반적으로 호환되는 �
 
 #### 소프트웨어 요구 사항
 
-- Oracle 또는 IBM Java 5 이상의 JRE
+- Oracle 또는 IBM Java 8 이상의 JRE
 
 Migration Center는 GUI 모드의 경우 스윙(Swing)을 사용하는 순수 자바
 애플리케이션이다. 이는 사용자의 하드웨어 및 운영 체제에 상관없이 대부분
 독립적으로 실행되지만, 오라클 자바 런타임 환경(JRE)에 의존적이다. 오라클 또는
-IBM Java 5 이상의 JRE를 설치할 것을 권장한다. GUI 모드로 Migration Center를
+IBM Java 8 이상의 JRE를 설치할 것을 권장한다. GUI 모드로 Migration Center를
 실행하려면, 사용자의 환경이 자바 스윙을 지원해야 한다.
 
-Migration Center는 64비트 마이크로소프트 윈도우 시스템의 JRE7과 함께 번들되었다.
+Migration Center는 64비트 마이크로소프트 윈도우 시스템의 JRE 8과 함께 번들되었다.
 그러므로 64비트 버전의 윈도우 사용자는 JRE에 대해 신경 쓸 필요가 없다. 그러나,
 다른 운영 체제 사용자는 JRE 및 관련 환경 변수를 알맞게 설정해야 한다.
 
@@ -418,10 +418,10 @@ Connector/J 파일, Informix JDBC 드라이버 파일, TimesTen의 JDBC 드라�
    사용해야 한다.
 
 2. SQL Server 2008, 2008 R2, 2012를 위한 JDBC 드라이버는 아래 링크에서 내려받아
-   사용할 수 있다. Migration Center는 JDBC 드라이버 버전 6.0와 JRE 7 환경에서
+   사용할 수 있다. Migration Center는 JDBC 드라이버 버전 6.0와 JRE 8 환경에서
    테스트 되었기 때문에, 동일한 드라이버 버전과 JRE 버전을 사용할 것을
    권장한다. 또한 SQL Server JDBC 드라이버는 JRE 7 이상을 요구하기 때문에,
-   Linux O/S에서는 JAVA_HOME 환경 변수의 값을 JRE 7 버전 이상이 설치된 경로로
+   Linux O/S에서는 JAVA_HOME 환경 변수의 값을 JRE 7 이상이 설치된 경로로
    설정해야 한다. 6.0 외의 JDBC 드라이버 버전을 사용하고자 할 때는, Microsoft
    JDBC Driver for SQL Server Support Matrix에서 드라이버 버전, 호환 SQL Server
    버전, 그리고 지원 가능한 JRE 버전을 확인해야 한다.  
@@ -8454,7 +8454,7 @@ JRE를 통해 실행되는데, 실행 장비의 운영체제가 Windows 이고 �
 ##### 해결방법
 
 실행 파일 migcenter.bat를 편집기로 열어, 환경변수 JAVA_HOME의 값을 장비에 기존에
-설치된 JRE 위치로 변경해야 한다. 변경할 JRE는 반드시 Java SE 5.0 이상이어야
+설치된 JRE 위치로 변경해야 한다. 변경할 JRE는 반드시 8 이상이어야
 한다.
 
 #### 오류 메시지 'Unable to insert (or update) NULL into NOT NULL column.'와 함께 데이터 이관에 실패한다.

--- a/ReleaseNotes/eng/Altibase_Migration_Center_7_9_Release_Notes.md
+++ b/ReleaseNotes/eng/Altibase_Migration_Center_7_9_Release_Notes.md
@@ -63,7 +63,7 @@ Migration Center is a database migration tool which enables users to migrate a t
 | BUG-48340 | If the table name includes underscore, the table column with a similar name is also included. |
 | BUG-48672 | As of Altibase 7.2, the warning window should not appear even if there is no default partition in the range partition table. |
 | BUG-49467 | Support TimesTen 11.2.1.9.10 to Altibase migration           |
-| BUG-49449 | Upgrade log4j version to 2.17.0 due to its security issue    |
+| BUG-49499 | Upgrade log4j version to 2.17.0 due to its security issue    |
 
 ### 2.2 Changes
 

--- a/ReleaseNotes/eng/Altibase_Migration_Center_7_9_Release_Notes.md
+++ b/ReleaseNotes/eng/Altibase_Migration_Center_7_9_Release_Notes.md
@@ -149,7 +149,7 @@ Migration Center is based on the following open-source libraries. The licenses a
 
 | JRE                         | Archive Name                                         |
 | --------------------------- | ---------------------------------------------------- |
-| Sun or IBM Java 5 or higher | MigrationCenter7.9.zip<br/>MigrationCenter7.9.tar.gz |
+| Sun or IBM Java 8 or higher | MigrationCenter7.9.zip<br/>MigrationCenter7.9.tar.gz |
 
 ### 2.5 Downloads
 

--- a/ReleaseNotes/eng/Altibase_Migration_Center_7_9_Release_Notes.md
+++ b/ReleaseNotes/eng/Altibase_Migration_Center_7_9_Release_Notes.md
@@ -14,7 +14,7 @@
 Altibase Migration Center 7.9 Release Notes
 ===============================
 
-**(Nov. 11, 2021)**
+**(Dec. 31, 2021)**
 
 ## 1. Abstract
 
@@ -33,8 +33,8 @@ Altibase Migration Center 7.9 Release Notes
 
 | Mode | JRE                         | OS Graphic Library |
 | ---- | --------------------------- | ------------------ |
-| GUI  | Sun or IBM Java 5 or higher | Required           |
-| CLI  | Sun or IBM Java 5 or higher | Not required       |
+| GUI  | Sun or IBM Java 8 or higher | Required           |
+| CLI  | Sun or IBM Java 8 or higher | Not required       |
 
 Migration Center is a pure Java-based client application relying on the JAVA Runtime Environment (JRE) instead of the client's hardware or an operating system. In order to execute Migration Center in the GUI mode, however, additional support for the graphic library of operating system is required.
 
@@ -55,7 +55,7 @@ Migration Center is a database migration tool which enables users to migrate a t
 | :-------- | :----------------------------------------------------------- |
 | BUG-47352 | Changes in "Partitioned Table Conversion" during the reconcile phase are not kept when returning after next or previous step |
 | BUG-47372 | Need to improve type conversion method for local variables in PSM |
-| BUG-47376 | Support source DDL with ALTIBASE dbms_metadata since 7       |
+| BUG-47376 | Support source DDL with dbms_metadata since Altibase 7       |
 | BUG-47381 | If the object referenced by a synonym is not a build target, hang occurs in the reconcile stage. |
 | BUG-47402 | Support TimesTen direct connection                           |
 | BUG-47408 | Reserved words allowed as column names must be excluded from _poc autoconversion. |
@@ -63,12 +63,13 @@ Migration Center is a database migration tool which enables users to migrate a t
 | BUG-48340 | If the table name includes underscore, the table column with a similar name is also included. |
 | BUG-48672 | As of Altibase 7.2, the warning window should not appear even if there is no default partition in the range partition table. |
 | BUG-49467 | Support TimesTen 11.2.1.9.10 to Altibase migration           |
-| BUG-49449 | Upgrade log4j version to 2.15.0 due to [CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q) security issue |
+| BUG-49449 | Upgrade log4j version to 2.17.0 due to its security issue    |
 
 ### 2.2 Changes
 
 Features that have been added, deleted or updated in Migration Center are listed and explained below.
 
+* Due to security issues, log4j has been updated to the latest version, and the minimum JRE version for running Migration Center is changed from 1.5 to 8.
 * Bundled JRE version in Migration Center is updated from 7 to 8 in order to support Altibase 7.2 JDBC that requires JRE 8 or higher.
 
 #### 2.2.1 Version Updates
@@ -87,7 +88,7 @@ Migration Center Version
   
   * Altibase : Altibase 4.3.9 or higher
   * ORACLE : Oracle 9i ~ 11g
-  * MS-SQL :  MS-SQL 2005-2012
+  * MS-SQL :  MS-SQL 2005 ~ 2012
   * MySQL : MySQL 5.0 ~ 5.5
   * Informix : Informix 11.50
   * TimesTen : TimesTen 7.0, TimesTen 11.2

--- a/ReleaseNotes/kor/Altibase_Migration_Center_7_9_Release_Notes.md
+++ b/ReleaseNotes/kor/Altibase_Migration_Center_7_9_Release_Notes.md
@@ -11,7 +11,7 @@
 
 # Altibase Migration Center 7.9 Release Notes
 
-**(Nov. 11, 2021)**
+**(Dec. 31, 2021)**
 
 ## 1. 개요
 
@@ -30,8 +30,8 @@
 
 | Mode | JRE                      | OS Graphic Library |
 | ---- | ------------------------ | ------------------ |
-| GUI  | Sun 또는 IBM Java 5 이상 | 필수               |
-| CLI  | Sun 또는 IBM Java 5 이상 | 필수 아님          |
+| GUI  | Sun 또는 IBM Java 8 이상 | 필수               |
+| CLI  | Sun 또는 IBM Java 8 이상 | 필수 아님          |
 
 Migration Center는 순수 Java 기반 클라이언트 애플리케이션으로, 클라이언트의 하드웨어나 OS보다 JAVA Runtime Environment (JRE)에 의존한다. 단, Migration Center를 GUI 모드로 실행하기 위해 운영 체제의 그래픽 라이브러리에 대한 추가 지원이 필요하다.
 
@@ -60,12 +60,13 @@ Migration Center는 데이터베이스 마이그레이션을 위한 도구로서
 | BUG-48340 | 테이블 이름에 밑줄(_)이 포함된 경우 유사한 이름을 가진 테이블 컬럼도 포함된다. |
 | BUG-48672 | Altibase 7.2부터 범위 파티션드 테이블에 기본 파티션이 없더라도 경고창이 나타나지 않는다. |
 | BUG-49467 | TimesTen 11.2.1.9.10으로부터 알티베이스로의 마이그레이션을 지원한다. |
-| BUG-49499 | [CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q) 보안 문제로 log4j를 2.15.0 버전으로 업그레이드해야 한다. |
+| BUG-49499 | log4j 보안 문제로 2.17.0 버전으로 업그레이드 한다.           |
 
 ### 2.2 변경사항
 
 Migration Center에 추가, 삭제 또는 변경된 기능들은 다음과 같다.
 
+- 보안 문제로 log4j 최신 버전으로 업데이트되어 Migration Center를 구동하기 위한  JRE 최소 버전이 1.5에서 8로 변경되었다.
 - JRE 8 이상을 요구하는 Altibase 7.2 JDBC를 지원하기 위해 Migration Center에 포함된 JRE 버전이 7에서 8로 업데이트되었다.
 
 #### 2.2.1 버전 업데이트
@@ -83,7 +84,7 @@ Migration Center 버전
 - 원본 데이터베이스
   - Altibase : Altibase 4.3.9 이상 버전
   - ORACLE : Oracle 9i ~ 11g
-  - MS-SQL : MS-SQL 2005-2012
+  - MS-SQL : MS-SQL 2005 ~ 2012
   - MySQL : MySQL 5.0 ~ 5.5
   - Informix : Informix 11.50
   - TimesTen : TimesTen 7.0, TimesTen 11.2
@@ -141,7 +142,7 @@ Migration Center는 아래의 오픈소스 라이브러리에 기반한다. 라�
 
 | JRE                      | Archive Name                                     |
 | ------------------------ | ------------------------------------------------ |
-| Sun 또는 IBM Java 5 이상 | MigrationCenter7.9.zip MigrationCenter7.9.tar.gz |
+| Sun 또는 IBM Java 8 이상 | MigrationCenter7.9.zip MigrationCenter7.9.tar.gz |
 
 ### 2.5 다운로드
 


### PR DESCRIPTION
1. 릴리즈 노트, 매뉴얼: log4j 업데이트로 Migration Center 최소 JRE 버전이 1.5 -> 8으로 변경
2. 릴리즈 노트 날짜 조정

수정량이 얼마 되지 않습니다. 가능하면 12/24까지 리뷰 부탁드립니다.