### PR TITLE
BUG-49647 Support Linux kernel 4.x

### DIFF
--- a/Manuals/Altibase_7.1/eng/Utilities Manual.md
+++ b/Manuals/Altibase_7.1/eng/Utilities Manual.md
@@ -2699,7 +2699,7 @@ altiMon uses PICL library written in C language in order to collect information 
 | ----- | --------------------- | --------------------------------- | -------------------------------- |
 | AIX   | ppc64                 | OS Version 5.3, 6.1, 7.1          | aix-ppc64-5.so                   |
 | HP-UX | ia64                  | IA64                              | hpux-ia64-11.sl                  |
-| LINUX | X86_64</br> ppc64(le) | OS Version 2.6</br> glibc 2.5 or later | linux-x64.so </br>linux-ppc64.so |
+| LINUX | X86_64</br> ppc64(le) | OS Version 2 ~ 4</br> glibc 2.5 or later | linux-x64.so </br>linux-ppc64.so |
 
 it can also be used after checking whether the PICL for the lower version works on the OS version that is not supported.
 

--- a/Manuals/Altibase_7.1/kor/Utilities Manual.md
+++ b/Manuals/Altibase_7.1/kor/Utilities Manual.md
@@ -3320,11 +3320,11 @@ altiMon은 주로 OS 정보와 DB 정보를 모니터링하며, 자세한 설명
 altiMon은 OS 정보를 수집하기 위해 C언어로 작성된 PICL 라이브러리를 사용한다.
 PICL 라이브러리를 사용할 수 있는 운영체제는 아래와 같다.
 
-| OS    | CPU                   | Version                           | PICL Library                     |
-| ----- | --------------------- | --------------------------------- | -------------------------------- |
-| AIX   | ppc64                 | OS Version 5.3, 6.1, 7.1          | aix-ppc64-5.so                   |
-| HP-UX | ia64                  | IA64                              | hpux-ia64-11.sl                  |
-| LINUX | X86_64</br> ppc64(le) | OS Version 2.6</br> glibc 2.5이상 | linux-x64.so </br>linux-ppc64.so |
+| OS    | CPU                   | Version                             | PICL Library                     |
+| ----- | --------------------- | ----------------------------------- | -------------------------------- |
+| AIX   | ppc64                 | OS Version 5.3, 6.1, 7.1            | aix-ppc64-5.so                   |
+| HP-UX | ia64                  | IA64                                | hpux-ia64-11.sl                  |
+| LINUX | X86_64</br> ppc64(le) | OS Version 2 ~ 4</br> glibc 2.5이상 | linux-x64.so </br>linux-ppc64.so |
 
 지원하지 않는 OS 버전에서 아래 방법으로 하위 버전용 PICL이 동작하는지를 확인한 후에 사용할 수도 있다.
 

--- a/Manuals/Altibase_7.2/eng/Utilities Manual.md
+++ b/Manuals/Altibase_7.2/eng/Utilities Manual.md
@@ -2702,7 +2702,7 @@ altiMon uses PICL library written in C language in order to collect information 
 | ----- | --------------------- | --------------------------------- | -------------------------------- |
 | AIX   | ppc64                 | OS Version 5.3, 6.1, 7.1          | aix-ppc64-5.so                   |
 | HP-UX | ia64                  | IA64                              | hpux-ia64-11.sl                  |
-| LINUX | X86_64</br> ppc64(le) | OS Version 2.6</br> glibc 2.5 or later | linux-x64.so </br>linux-ppc64.so |
+| LINUX | X86_64</br> ppc64(le) | OS Version 2 ~ 4</br> glibc 2.5 or later | linux-x64.so </br>linux-ppc64.so |
 
 it can also be used after checking whether the PICL for the lower version works on the OS version that is not supported.
 

--- a/Manuals/Altibase_7.2/kor/Utilities Manual.md
+++ b/Manuals/Altibase_7.2/kor/Utilities Manual.md
@@ -2862,11 +2862,11 @@ altiMon은 주로 OS 정보와 DB 정보를 모니터링하며, 자세한 설명
 altiMon은 OS 정보를 수집하기 위해 C언어로 작성된 PICL 라이브러리를 사용한다.
 PICL 라이브러리를 사용할 수 있는 운영체제는 아래와 같다.
 
-| OS    | CPU                   | Version                           | PICL Library                     |
-| ----- | --------------------- | --------------------------------- | -------------------------------- |
-| AIX   | ppc64                 | OS Version 5.3, 6.1, 7.1          | aix-ppc64-5.so                   |
-| HP-UX | ia64                  | IA64                              | hpux-ia64-11.sl                  |
-| LINUX | X86_64</br> ppc64(le) | OS Version 2.6</br> glibc 2.5이상 | linux-x64.so </br>linux-ppc64.so |
+| OS    | CPU                   | Version                             | PICL Library                     |
+| ----- | --------------------- | ----------------------------------- | -------------------------------- |
+| AIX   | ppc64                 | OS Version 5.3, 6.1, 7.1            | aix-ppc64-5.so                   |
+| HP-UX | ia64                  | IA64                                | hpux-ia64-11.sl                  |
+| LINUX | X86_64</br> ppc64(le) | OS Version 2 ~ 4</br> glibc 2.5이상 | linux-x64.so </br>linux-ppc64.so |
 
 지원하지 않는 OS 버전에서 아래 방법으로 하위 버전용 PICL이 동작하는지를 확인한 후에 사용할 수도 있다.
 

--- a/Manuals/Altibase_trunk/eng/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/eng/Utilities Manual.md
@@ -2696,11 +2696,11 @@ $ altimon.sh stop
 
 altiMon uses PICL library written in C language in order to collect information on operating system. The PICL library is available on the operation systems describe in the chart below. 
 
-| OS    | CPU          | Version                           | PICL Library                |
-| ----- | ------------ | --------------------------------- | --------------------------- |
-| AIX   | ppc64        | OS Version 5.3, 6.1, 7.1          | aix-ppc64-5.so              |
-| HP-UX | ia64         | IA64                              | hpux-ia64-11.sl             |
-| LINUX | X86_64 ppc64 | OS Version 2.6 glibc 2.5 or later | linux-x64.so linux-ppc64.so |
+| OS    | CPU          | Version                                 | PICL Library                |
+| ----- | ------------ | --------------------------------------- | --------------------------- |
+| AIX   | ppc64        | OS Version 5.3, 6.1, 7.1                | aix-ppc64-5.so              |
+| HP-UX | ia64         | IA64                                    | hpux-ia64-11.sl             |
+| LINUX | X86_64 ppc64 | OS Version 2 ~ 4<br> glibc 2.5 or later | linux-x64.so linux-ppc64.so |
 
 it can also be used after checking whether the PICL for the lower version works on the OS version that is not supported.
 

--- a/Manuals/Altibase_trunk/kor/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/kor/Utilities Manual.md
@@ -3299,11 +3299,11 @@ altiMon은 주로 OS 정보와 DB 정보를 모니터링하며, 자세한 설명
 altiMon은 OS 정보를 수집하기 위해 C언어로 작성된 PICL 라이브러리를 사용한다.
 PICL 라이브러리를 사용할 수 있는 운영체제는 아래와 같다.
 
-| OS    | CPU              | Version                      | PICL Library                |
-|-------|------------------|------------------------------|-----------------------------|
-| AIX   | ppc64            | OS Version 5.3, 6.1, 7.1     | aix-ppc64-5.so              |
-| HP-UX | ia64             | IA64                         | hpux-ia64-11.sl             |
-| LINUX | X86_64 ppc64(le) | OS Version 2.6 glibc 2.5이상 | linux-x64.so linux-ppc64.so |
+| OS    | CPU              | Version                            | PICL Library                |
+| ----- | ---------------- | ---------------------------------- | --------------------------- |
+| AIX   | ppc64            | OS Version 5.3, 6.1, 7.1           | aix-ppc64-5.so              |
+| HP-UX | ia64             | IA64                               | hpux-ia64-11.sl             |
+| LINUX | X86_64 ppc64(le) | OS Version 2 ~ 4<br> glibc 2.5이상 | linux-x64.so linux-ppc64.so |
 
 지원하지 않는 OS 버전에서 아래 방법으로 하위 버전용 PICL이 동작하는지를 확인한 후에 사용할 수도 있다.
 


### PR DESCRIPTION
INC-46277  [CUBOX] 솔루션 도입 검토 PoC : altiMon의 Ubuntu 16, 18 버전 지원(Linux kernel 4.x) 지원 여부 검증 및 수정 완료 후 매뉴얼 업데이트 사항입니다.

리뷰라기보다는 notification을 위해 만든 pull-request 라 특별한 이슈가 없으면 차주 월(3/21) 머지 하도록 하겠습니다.

감사합니다.