### PR TITLE
BUG-49546 jdbc 메뉴얼에 getcolumns_return_jdbctype 연결속성 추가

### DIFF
--- a/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
@@ -952,7 +952,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns()의 data_type 결과값이 java.sql.Types 값으로 넘어올지 <br>지정한다. 해당 값을 true로 설정하면 jdbc 스펙에 따라 java.sql.Types 값이<br> 넘어오지만 false일 경우 알티베이스 내부 값이 넘어오게 된다.|
+| 설명      | DatabaseMetaData.getColumns()의 DATA_TYPE 컬럼 결과값을 JDBC 스펙에 따른 java.sql.Types<br> 값으로 반환할지, 알티베이스 V$DATATYPE에 정의된 값을 반환할지 지정한다. 해당 값을 true로<br> 설정하면 java.sql.Types에 정의된 값으로 , false로 설정하면 V$DATATYPE에 정의된 데이터 타입 값을<br> 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
@@ -945,6 +945,15 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 설정 범위 | N/A                                                          |
 | 설명      | DatabaseMetaData.getProcedures(), DatabaseMetaData.getProcedureColumns()<br>의 결과에 function 객체도 포함할지 지정한다. 해당 값을 false로 설정하면 function 객체<br>정보를 얻기 위해서 DatabaseMetaData.getFunctions()와 DatabaseMetaData.getFunctionColumns()를 별도로 사용해야 한다.<br> JDBC spec. 4.2를 지원하는 Altibase42.jar 에서만 효과가 있으며 Altibase.jar에서는 설정해도 효과가 없다.|
 
+##### getcolumns_return_jdbctype
+
+| 기본값    | false                                                         |
+| --------- | :----------------------------------------------------------- |
+| 값의 범위 | [true \| false ]                                             |
+| 필수 여부 | No                                                           |
+| 설정 범위 | N/A                                                          |
+| 설명      | DatabaseMetaData.getColumns()의 data_type 결과값이 java.sql.Types 값으로 넘어올지 <br>지정한다. 해당 값을 true로 설정하면 jdbc 스펙에 따라 java.sql.Types 값이<br> 넘어오지만 false일 경우 알티베이스 내부 값이 넘어오게 된다.|
+
 ##### batch_setbytes_use_lob
 
 | 기본값    | true                                                         |

--- a/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
@@ -952,7 +952,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns()의 DATA_TYPE 컬럼 결과값을 JDBC 스펙에 따른 java.sql.Types<br> 값으로 반환할지, 알티베이스 V$DATATYPE에 정의된 값을 반환할지 지정한다. 해당 값을 true로<br> 설정하면 java.sql.Types에 정의된 값으로 , false로 설정하면 V$DATATYPE에 정의된 데이터 타입 값을<br> 반환한다.|
+| 설명      | DatabaseMetaData.getColumns 메서드의 반환하는 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.1/kor/JDBC User's Manual.md
@@ -952,7 +952,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns 메서드의 반환하는 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
+| 설명      | DatabaseMetaData.getColumns 메서드의 반환 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
@@ -903,6 +903,15 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 설정 범위 | N/A                                                          |
 | 설명      | DatabaseMetaData.getProcedures(), DatabaseMetaData.getProcedureColumns()<br/>의 결과에 function 객체도 포함할지 지정한다. 해당 값을 false로 설정하면 function 객체<br/>정보를 얻기 위해서 DatabaseMetaData.getFunctions()와 DatabaseMetaData.getFunctionColumns()를 별도로 사용해야 한다. |
 
+##### getcolumns_return_jdbctype
+
+| 기본값    | false                                                         |
+| --------- | :----------------------------------------------------------- |
+| 값의 범위 | [true \| false ]                                             |
+| 필수 여부 | No                                                           |
+| 설정 범위 | N/A                                                          |
+| 설명      | DatabaseMetaData.getColumns()의 data_type 결과값이 java.sql.Types 값으로 넘어올지 <br>지정한다. 해당 값을 true로 설정하면 jdbc 스펙에 따라 java.sql.Types 값이<br> 넘어오지만 false일 경우 알티베이스 내부 값이 넘어오게 된다.|
+
 ##### batch_setbytes_use_lob
 
 | 기본값    | true                                                         |

--- a/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
@@ -910,7 +910,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns()의 DATA_TYPE 컬럼 결과값을 JDBC 스펙에 따른 java.sql.Types<br> 값으로 반환할지, 알티베이스 V$DATATYPE에 정의된 값을 반환할지 지정한다. 해당 값을 true로<br> 설정하면 java.sql.Types에 정의된 값으로 , false로 설정하면 V$DATATYPE에 정의된 데이터 타입 값을<br> 반환한다.|
+| 설명      | DatabaseMetaData.getColumns 메서드의 반환하는 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
@@ -910,7 +910,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns()의 data_type 결과값이 java.sql.Types 값으로 넘어올지 <br>지정한다. 해당 값을 true로 설정하면 jdbc 스펙에 따라 java.sql.Types 값이<br> 넘어오지만 false일 경우 알티베이스 내부 값이 넘어오게 된다.|
+| 설명      | DatabaseMetaData.getColumns()의 DATA_TYPE 컬럼 결과값을 JDBC 스펙에 따른 java.sql.Types<br> 값으로 반환할지, 알티베이스 V$DATATYPE에 정의된 값을 반환할지 지정한다. 해당 값을 true로<br> 설정하면 java.sql.Types에 정의된 값으로 , false로 설정하면 V$DATATYPE에 정의된 데이터 타입 값을<br> 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_7.2/kor/JDBC User's Manual.md
@@ -910,7 +910,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns 메서드의 반환하는 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
+| 설명      | DatabaseMetaData.getColumns 메서드의 반환 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
@@ -946,7 +946,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns()의 DATA_TYPE 컬럼 결과값을 JDBC 스펙에 따른 java.sql.Types<br> 값으로 반환할지, 알티베이스 V$DATATYPE에 정의된 값을 반환할지 지정한다. 해당 값을 true로<br> 설정하면 java.sql.Types에 정의된 값으로 , false로 설정하면 V$DATATYPE에 정의된 데이터 타입 값을<br> 반환한다.|
+| 설명      |  DatabaseMetaData.getColumns 메서드의 반환하는 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
@@ -939,6 +939,15 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 설정 범위 | N/A                                                          |
 | 설명      | DatabaseMetaData.getProcedures(), DatabaseMetaData.getProcedureColumns()<br>의 결과에 function 객체도 포함할지 지정한다. 해당 값을 false로 설정하면 function 객체<br>정보를 얻기 위해서 DatabaseMetaData.getFunctions()와 DatabaseMetaData.getFunctionColumns()를 별도로 사용해야 한다.|
 
+##### getcolumns_return_jdbctype
+
+| 기본값    | true                                                         |
+| --------- | :----------------------------------------------------------- |
+| 값의 범위 | [true \| false ]                                             |
+| 필수 여부 | No                                                           |
+| 설정 범위 | N/A                                                          |
+| 설명      | DatabaseMetaData.getColumns()의 data_type 결과값이 java.sql.Types 값으로 넘어올지 <br>지정한다. 해당 값을 true로 설정하면 jdbc 스펙에 따라 java.sql.Types 값이<br> 넘어오지만 false일 경우 알티베이스 내부 값이 넘어오게 된다.|
+
 ##### batch_setbytes_use_lob
 
 | 기본값    | true                                                         |

--- a/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
@@ -946,7 +946,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      |  DatabaseMetaData.getColumns 메서드의 반환하는 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
+| 설명      |  DatabaseMetaData.getColumns 메서드의 반환 결과 중 DATA_TYPE 값을 정의한다.<br> true는 JDBC API에서 정의한 java.sql.Types의 SQL 데이터 형식으로 반환하고 false는 V$DATATYPE에<br> 정의된 데이터 타입 형식으로 반환한다.|
 
 ##### batch_setbytes_use_lob
 

--- a/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
+++ b/Manuals/Altibase_trunk/kor/JDBC User's Manual.md
@@ -946,7 +946,7 @@ Altibase에 접속할 때 사용 가능한 연결 속성에 대해 기술한다.
 | 값의 범위 | [true \| false ]                                             |
 | 필수 여부 | No                                                           |
 | 설정 범위 | N/A                                                          |
-| 설명      | DatabaseMetaData.getColumns()의 data_type 결과값이 java.sql.Types 값으로 넘어올지 <br>지정한다. 해당 값을 true로 설정하면 jdbc 스펙에 따라 java.sql.Types 값이<br> 넘어오지만 false일 경우 알티베이스 내부 값이 넘어오게 된다.|
+| 설명      | DatabaseMetaData.getColumns()의 DATA_TYPE 컬럼 결과값을 JDBC 스펙에 따른 java.sql.Types<br> 값으로 반환할지, 알티베이스 V$DATATYPE에 정의된 값을 반환할지 지정한다. 해당 값을 true로<br> 설정하면 java.sql.Types에 정의된 값으로 , false로 설정하면 V$DATATYPE에 정의된 데이터 타입 값을<br> 반환한다.|
 
 ##### batch_setbytes_use_lob
 


### PR DESCRIPTION
jdbc 메뉴얼에 getcolumns_return_jdbctype 속성에 대한 내용을 추가하였습니다.

기본값 같은 경우 하위호환성을 위해 710, 720은  false이고 trunk만 true입니다.

참고하시기 바랍니다.