### PR TITLE
BUG-47668

### DIFF
--- a/Manuals/Altibase_7.1/eng/DB Link User's Manual.md
+++ b/Manuals/Altibase_7.1/eng/DB Link User's Manual.md
@@ -2303,7 +2303,7 @@ This is used to specify JVM bit for AltiLinker on JVM (Java Virtual Machine).
 
 ##### Range
 
-[8MB, 512MB]
+[128MB, 4096MB]
 
 ##### Description
 
@@ -2313,11 +2313,11 @@ This property specifies the initial size, in bytes, of the memory pool allocated
 
 ##### Default Value
 
-512 MBytes
+4096 MBytes
 
 ##### Range
 
-[16MB, 512MB]
+[512MB, 32768MB]
 
 ##### Description
 


### PR DESCRIPTION
DB Link User's Manual에서 ALTILINKER_JVM_MEMORY_POOL_INIT_SIZE, ALTILINKER_JVM_MEMORY_POOL_MAX_SIZE의 정보가 잘못되어 있어 수정합니다.