### PR TITLE
BUG-49993 처리로 매뉴얼 업데이트

### DIFF
--- a/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
@@ -1784,7 +1784,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |  10  | BIGINT UNSIGNED    | NUMERIC(20,0)                   | Altibase에는 MySQL BIGINT UNSIGNED 타입과 호환 가능한 데이터 타입이 없으므로, 데이터 손실을 막기 위해 NUMERIC 타입으로 맵핑된다 |
 |  11  | DECIMAL (NUMERIC)  | VARCHAR(70)                     | Altibase에는 MySQL DECIMAL 타입과 호환 가능한 데이터 타입이 없으므로, 데이터 손실을 막기 위해 VARCHAR 타입으로 맵핑된다. |
 |  12  | FLOAT              | FLOAT                           |                                                              |
-|  13  | DOUBLE             | DOUBLE                          | TODO: BUG-49993                                              |
+|  13  | DOUBLE             | VARCHAR(310)                    | Altibase에는 MySQL DECIMAL 타입과 호환 가능한 데이터 타입이 없으므로, 데이터 손실을 막기 위해 VARCHAR 타입으로 맵핑된다. |
 |  14  | BIT                | VARBIT                          |                                                              |
 |  15  | DATETIME           | DATE                            | 시각 부분이 0으로 설정된다.                                  |
 |  16  | DATE               | DATE                            |                                                              |

--- a/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
@@ -1366,7 +1366,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |  10  | BIGINT UNSIGNED                 | NUMERIC(20,0)  | There is no compatible data type in Altibase for MySQL BIGINT UNSIGNED type, so NUMERIC type is used to prevent any data loss. |
 |  11  | DECIMAL (NUMERIC)               | VARCHAR(70)    | There is no compatible data type in Altibase for MySQL DECIMAL type, so VARCHAR type is used to prevent any data loss. |
 |  12  | FLOAT                           | FLOAT          |                                                              |
-|  13  | DOUBLE                          | VARCHAR(310)   | There is no compatible data type in Altibase for MySQL DOUBLE type, so VARCHAR type is used to prevent any data loss. |
+|  13  | DOUBLE                          | DOUBLE         |                                                              |
 |  14  | BIT                             | VARBIT         |                                                              |
 |  15  | DATETIME                        | DATE           | Time parts are set to ‘0'                                    |
 |  16  | DATE                            | DATE           |                                                              |

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -1784,7 +1784,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |  10  | BIGINT UNSIGNED    | NUMERIC(20,0)                   | Altibase에는 MySQL BIGINT UNSIGNED 타입과 호환 가능한 데이터 타입이 없으므로, 데이터 손실을 막기 위해 NUMERIC 타입으로 맵핑된다 |
 |  11  | DECIMAL (NUMERIC)  | VARCHAR(70)                     | Altibase에는 MySQL DECIMAL 타입과 호환 가능한 데이터 타입이 없으므로, 데이터 손실을 막기 위해 VARCHAR 타입으로 맵핑된다. |
 |  12  | FLOAT              | FLOAT                           |                                                              |
-|  13  | DOUBLE             | DOUBLE                          | TODO: BUG-49993                                              |
+|  13  | DOUBLE             | DOUBLE                          |                                                              |
 |  14  | BIT                | VARBIT                          |                                                              |
 |  15  | DATETIME           | DATE                            | 시각 부분이 0으로 설정된다.                                  |
 |  16  | DATE               | DATE                            |                                                              |


### PR DESCRIPTION
두가지 수정사항이 있습니다.

1. BUG-49993 처리로 MySQL Double data type을 Altibase Double data type으로 변경합니다.
2. Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md 파일에 내용이 BUG-49993 처리가 완료되지 않았는데, 선반영되었습니다. 원복이 필요합니다. 

차기 정식 버전 릴리즈때 Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md 파일을 Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md 로 이동하면 됩니다.