### PR TITLE
BUG-50406 manual update

### DIFF
--- a/Manuals/Altibase_7.1/kor/Utilities Manual.md
+++ b/Manuals/Altibase_7.1/kor/Utilities Manual.md
@@ -2747,7 +2747,14 @@ PID : 5230
 
 ### altiMon 시작
 
-1️⃣ JAVA_HOME 환경 변수를 설정한다.
+1️⃣ Java를 사용할 수 있게 PATH 환경 변수를 설정한다.
+
+```bash
+$ java -version
+java version "1.8.0_101"
+Java(TM) SE Runtime Environment (build 1.8.0_101-b13)
+Java HotSpot(TM) 64-Bit Server VM (build 25.101-b13, mixed mode)
+```
 
 2️⃣ altiMon 시작 명령을 수행한다.
 

--- a/Manuals/Altibase_trunk/kor/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/kor/Utilities Manual.md
@@ -2721,7 +2721,7 @@ PID : 5230
 
 ### altiMon 시작
 
-1️⃣ 최소 요구사항에 맞는 Java를 사용할 수 있게 PATH 환경 변수를 설정한다.
+1️⃣ Java를 사용할 수 있게 PATH 환경 변수를 설정한다.
 
 ```bash
 $ java -version

--- a/Manuals/Altibase_trunk/kor/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/kor/Utilities Manual.md
@@ -2721,7 +2721,14 @@ PID : 5230
 
 ### altiMon 시작
 
-1️⃣ JAVA_HOME 환경 변수를 설정한다.
+1️⃣ 최소 요구사항에 맞는 Java를 사용할 수 있게 PATH 환경 변수를 설정한다.
+
+```bash
+$ java -version
+java version "1.8.0_101"
+Java(TM) SE Runtime Environment (build 1.8.0_101-b13)
+Java HotSpot(TM) 64-Bit Server VM (build 25.101-b13, mixed mode)
+```
 
 2️⃣ altiMon 시작 명령을 수행한다.
 


### PR DESCRIPTION
- 증상: 부적절한 java version으로 인한 altimon.sh 시작 실패
- 원인: altimon.sh에는 $JAVA_HOME/bin/java으로 Java를 구동하는데, HP-UX에 설치된 Java의 경우 $JAVA_HOME/bin/java는 32bit 버전이며, $JAVA_HOME/bin/IA64W/java가 64bit 버전이다. JVM vendor 마다 java binary 위치가 달라질 수 있기 때문에, 유연하게 대처할 수 있도록 수정해야 한다.
- 해결: $JAVA_HOME에 대한 내용을 altimon.sh과 매뉴얼에서 수정한다. 

altimon.sh 수정사항
```
$ svn diff
Index: altimon.sh
===================================================================
--- altimon.sh  (리비전 95593)
+++ altimon.sh  (작업 사본)
@@ -2,8 +2,6 @@

 cd $ALTIBASE_HOME/altiMon

-#JAVA_HOME=/usr/java/jdk1.5.0_22
-
 JAVA_OPTIONS="-Xms25m -Xmx25m -XX:NewSize=20m"
 #PICL_LIB=-Dpicl="aix-ppc64-5.so"

@@ -25,7 +23,7 @@
     if [ "$GET_PID" = "" ]; then
       rm -f $ERR_LOG_FILE

-      nohup $JAVA_HOME/bin/java $JAVA_OPTIONS $PICL_LIB -jar altimon.jar > $ERR_LOG_FILE 2>&1 &
+      nohup java $JAVA_OPTIONS $PICL_LIB -jar altimon.jar > $ERR_LOG_FILE 2>&1 &
```
