### PR TITLE
Inital commit

### DIFF
--- a/Manuals/Altibase_trunk/kor/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/kor/Utilities Manual.md
@@ -504,7 +504,7 @@ aexport에 의해 생성된 모든 파일은 텍스트 파일이기 때문에 �
 
 DBMS_METADATA 패키지는 데이터베이스 딕셔너리로부터 객체 생성 DDL 구문 또는 권한 GRANT 구문을 추출하는 기능을 제공한다. 
 
-aexport는 DBMS_METADATA 패키지에 의존성을 가지기 때문에, aexport를 사용하기 위해서는 해당 패키지를 반드시 알티베이스에 설치해야 한다. 미설치된 알티베이스를 대상으로 aexport를 수행하면 다음과 같은 에러가 발생한다.
+aexport는 DBMS_METADATA 패키지에 의존성을 가지기 때문에, aexport를 사용하기 위해서는 해당 패키지를 반드시 알티베이스에 설치해야 한다. DBMS_METADATA 패키지가 설치되지 않은 알티베이스를 대상으로 aexport를 수행하면 다음과 같은 에러가 발생한다.
 
 ```bash
 $ aexport -s localhost -u sys -p manager

--- a/Manuals/Altibase_trunk/kor/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/kor/Utilities Manual.md
@@ -500,6 +500,25 @@ aexport에 의해 생성된 모든 파일은 텍스트 파일이기 때문에 �
     생성하는 SQL 스크립트를 포함한다. 또한, ALL_OBJECT_CONSTRATINS.sql을
     실행하는 run_is_con.sh 쉘 스크립트 파일이 생성된다.
 
+### 알티베이스 요구사항
+
+DBMS_METADATA 패키지는 데이터베이스 딕셔너리로부터 객체 생성 DDL 구문 또는 권한 GRANT 구문을 추출하는 기능을 제공한다. 
+
+aexport는 DBMS_METADATA 패키지에 의존성을 가지기 때문에, aexport를 사용하기 위해서는 해당 패키지를 반드시 알티베이스에 설치해야 한다. 미설치된 알티베이스를 대상으로 aexport를 수행하면 다음과 같은 에러가 발생한다.
+
+```bash
+$ aexport -s localhost -u sys -p manager
+-----------------------------------------------------------------
+     Altibase Export Script Utility.
+     Release Version 7.3.0.0.0
+     Copyright 2000, ALTIBASE Corporation or its subsidiaries.
+     All Rights Reserved.
+-----------------------------------------------------------------
+[ERR-91144 : DBMS_METADATA package does not exist.]
+```
+
+> DBMS_METADATA 저장 패키지에 대한 자세한 설명과 예제는 *Stored Procedures Manual*의 'Altibase 저장 패키지'를 참조하기 바란다.
+
 ### aexport 설정
 
 aexport는 서버에 접속하기 위해서 다음과 같은 정보가 필요하다.

--- a/Manuals/Altibase_trunk/kor/Utilities Manual.md
+++ b/Manuals/Altibase_trunk/kor/Utilities Manual.md
@@ -517,7 +517,7 @@ $ aexport -s localhost -u sys -p manager
 [ERR-91144 : DBMS_METADATA package does not exist.]
 ```
 
-> DBMS_METADATA 저장 패키지에 대한 자세한 설명과 예제는 *Stored Procedures Manual*의 'Altibase 저장 패키지'를 참조하기 바란다.
+> DBMS_METADATA 패키지에 대한 자세한 설명과 예제는 *Stored Procedures Manual*의 'Altibase 저장 패키지'를 참조하기 바란다.
 
 ### aexport 설정
 


### PR DESCRIPTION
aexport 요구사항인 DBMS_METADATA 패키지가 aexport 매뉴얼에 언급되지 않아 추가합니다. (BUG-47159 [ux-aexport] TASK-7189 commit dbms_metadata 패키지를 aexport에 적용)

7.1.0부터 적용되었지만 7.1.0은 DBMS_METADATA 패키지 없이 aexport가 동작하며, 7.3.0 부터 DBMS_METADATA 패키지가 aexport 필수 사항입니다.