### PR TITLE
BUG-50263

### DIFF
--- a/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
@@ -1308,7 +1308,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |  6   | NUMBER        | NUMBER          | NUMBER type columns defined without precision and scale in Oracle are converted to the same NUMBER type columns without precision and scale for Altibase. *Both Oracle and Altibase internally handle NUMBER type columns defined without precision and scale as FLOAT type in the database. |
 |  7   | FLOAT         | FLOAT           |                                                              |
 |  8   | BINARY FLOAT  | FLOAT           |                                                              |
-|  9   | BINARY DOUBLE | VARCHAR(310)    | There is no compatible data type in Altibase for the Oracle binary double type, so the data is stored in character form to prevent loss. |
+|  9   | BINARY DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values can be loss during migration. |
 |  10  | DATE          | DATE            |                                                              |
 |  11  | TIMESTAMP     | DATE            | A small amount of data loss may occur due to the difference in scale. <br/>In Oracle, the scale of a timestamp value is nanoseconds (9 digits), whereas in Altibase, the scale of a timestamp value is microseconds (6 digits) |
 |  12  | RAW           | BLOB            |                                                              |
@@ -1427,7 +1427,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |      | Source        | Destination     | Notice                                                       |
 | :--: | :------------ | :-------------- | :----------------------------------------------------------- |
 |  1   | BINARY        | BLOB            |                                                              |
-|  2   | BINARY_DOUBLE | VARCHAR(310)    |                                                              |
+|  2   | BINARY_DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values can be loss during migration. |
 |  3   | BINARY_FLOAT  | FLOAT           |                                                              |
 |  4   | BLOB          | BLOB            |                                                              |
 |  5   | CHAR          | CHAR            | CHAR type columns defined with character length in TimesTen are automatically converted to CHAR type columns with byte length in Altibase, because in Altibase, CHAR type columns can be defined only with byte length. |
@@ -1516,7 +1516,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |  5   | LONG          | CLOB            |                                                              |
 |  6   | NUMBER        | NUMERIC         | NUMBER type columns defined without precision and scale in Tibero are converted to the same NUMBER type columns without precision and scale for Altibase. *Both Tibero and Altibase internally handle NUMBER type columns defined without precision and scale as FLOAT type in the database. |
 |  7   | BINARY FLOAT  | FLOAT           |                                                              |
-|  8   | BINARY DOUBLE | VARCHAR(310)    | There is no compatible data type in Altibase for the Tibero binary double type, so the data is stored in character form to prevent loss. |
+|  8   | BINARY DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values can be loss during migration. |
 |  9   | DATE          | DATE            |                                                              |
 |  10  | TIME          | DATE            |                                                              |
 |  11  | TIMESTAMP     | DATE            | A small amount of data loss may occur due to the difference in scale. In Tibero, the scale of a timestamp value is nanoseconds (9 digits), whereas in Altibase, the scale of a timestamp value is microseconds (6 digits). |

--- a/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
@@ -1308,7 +1308,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |  6   | NUMBER        | NUMBER          | NUMBER type columns defined without precision and scale in Oracle are converted to the same NUMBER type columns without precision and scale for Altibase. *Both Oracle and Altibase internally handle NUMBER type columns defined without precision and scale as FLOAT type in the database. |
 |  7   | FLOAT         | FLOAT           |                                                              |
 |  8   | BINARY FLOAT  | FLOAT           |                                                              |
-|  9   | BINARY DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values can be loss during migration. |
+|  9   | BINARY DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values are not migrated. |
 |  10  | DATE          | DATE            |                                                              |
 |  11  | TIMESTAMP     | DATE            | A small amount of data loss may occur due to the difference in scale. <br/>In Oracle, the scale of a timestamp value is nanoseconds (9 digits), whereas in Altibase, the scale of a timestamp value is microseconds (6 digits) |
 |  12  | RAW           | BLOB            |                                                              |
@@ -1427,7 +1427,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |      | Source        | Destination     | Notice                                                       |
 | :--: | :------------ | :-------------- | :----------------------------------------------------------- |
 |  1   | BINARY        | BLOB            |                                                              |
-|  2   | BINARY_DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values can be loss during migration. |
+|  2   | BINARY_DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values are not migrated. |
 |  3   | BINARY_FLOAT  | FLOAT           |                                                              |
 |  4   | BLOB          | BLOB            |                                                              |
 |  5   | CHAR          | CHAR            | CHAR type columns defined with character length in TimesTen are automatically converted to CHAR type columns with byte length in Altibase, because in Altibase, CHAR type columns can be defined only with byte length. |
@@ -1516,7 +1516,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 |  5   | LONG          | CLOB            |                                                              |
 |  6   | NUMBER        | NUMERIC         | NUMBER type columns defined without precision and scale in Tibero are converted to the same NUMBER type columns without precision and scale for Altibase. *Both Tibero and Altibase internally handle NUMBER type columns defined without precision and scale as FLOAT type in the database. |
 |  7   | BINARY FLOAT  | FLOAT           |                                                              |
-|  8   | BINARY DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values can be loss during migration. |
+|  8   | BINARY DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values are not migrated. |
 |  9   | DATE          | DATE            |                                                              |
 |  10  | TIME          | DATE            |                                                              |
 |  11  | TIMESTAMP     | DATE            | A small amount of data loss may occur due to the difference in scale. In Tibero, the scale of a timestamp value is nanoseconds (9 digits), whereas in Altibase, the scale of a timestamp value is microseconds (6 digits). |

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -1727,7 +1727,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |  6   | NUMBER        | NUMBER            | 오라클에서 precision과 scale 없이 정의된 NUMBER 타입 컬럼은 Altibase에서도 동일하게 precision과 scale이 없는 NUMBER 타입으로 변환된다. \*참고: 오라클과 Altibase 모두 precision과 scale 없이 NUMBER 타입으로 컬럼을 정의하면 데이터베이스 내부적으로 FLOAT 타입으로 다루어진다. |
 |  7   | FLOAT         | FLOAT             |                                                              |
 |  8   | BINARY FLOAT  | FLOAT             |                                                              |
-|  9   | BINARY DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 수행 중 손실이 가능하다. |
+|  9   | BINARY DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 되지 않는다. |
 |  10  | DATE          | DATE              |                                                              |
 |  11  | TIMESTAMP     | DATE              | 스케일의 차이로 인해서 소량의 데이터 손실이 발생할 수 있다. 오라클에서는 타임스탬프 값의 스케일이 나노초(9자리 수)인 반면, Altibase에서는 타임스탬프 값의 스케일이 마이크로초(6자리 수)이다. |
 |  12  | RAW           | BLOB              |                                                              |
@@ -1840,7 +1840,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |      | 원본          | 대상              | 주의 사항                                                    |
 | :--: | :------------ | :---------------- | :----------------------------------------------------------- |
 |  1   | BINARY        | BLOB              |                                                              |
-|  2   | BINARY_DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 수행 중 손실이 가능하다. |
+|  2   | BINARY_DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 되지 않는다. |
 |  3   | BINARY_FLOAT  | FLOAT             |                                                              |
 |  4   | BLOB          | BLOB              |                                                              |
 |  5   | CHAR          | CHAR              | Altibase의 CHAR 타입은 byte 길이로만 정의할 수 있기 때문에 TimesTen에서 문자 길이로 정의된 컬럼의 경우 자동으로 바이트 길이로 변환된다. |
@@ -1929,7 +1929,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |  5   | LONG          | CLOB            |                                                              |
 |  6   | NUMBER        | NUMERIC         | 티베로에서 precision과 scale 없이 정의된 NUMBER 타입 컬럼은 Altibase에서도 동일하게 precision과 scale이 없는 NUMBER 타입으로 변환된다. \*참고: 티베로와 Altibase 모두 precision과 scale이 없는 NUMBER 타입으로 컬럼을 정의하면 데이터베이스 내부적으로 FLOAT 타입으로 처리한다. |
 |  7   | BINARY FLOAT  | FLOAT           |                                                              |
-|  8   | BINARY DOUBLE | DOUBLE          | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 수행 중 손실이 가능하다. |
+|  8   | BINARY DOUBLE | DOUBLE          | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 되지 않는다. |
 |  9   | DATE          | DATE            |                                                              |
 |  10  | TIME          | DATE            |                                                              |
 |  11  | TIMESTAMP     | DATE            | Scale의 차이로 인해서 소량의 데이터 손실이 발생할 수 있다. 티베로에서는 타임스탬프 값의 스케일이 나노초(9자리 수)인 반면, , Altibase에서는 타임스탬프 값의 scale이 마이크로초(6자리 수)이다. |

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -1727,7 +1727,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |  6   | NUMBER        | NUMBER            | 오라클에서 precision과 scale 없이 정의된 NUMBER 타입 컬럼은 Altibase에서도 동일하게 precision과 scale이 없는 NUMBER 타입으로 변환된다. \*참고: 오라클과 Altibase 모두 precision과 scale 없이 NUMBER 타입으로 컬럼을 정의하면 데이터베이스 내부적으로 FLOAT 타입으로 다루어진다. |
 |  7   | FLOAT         | FLOAT             |                                                              |
 |  8   | BINARY FLOAT  | FLOAT             |                                                              |
-|  9   | BINARY DOUBLE | VARCHAR(310)      | Altibase 에는 오라클 BINARY DOUBLE 타입과 호환되는 데이터 타입이 없으므로 데이터 손실을 막기 위해 문자 형으로 저장된다. |
+|  9   | BINARY DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 수행 중 손실이 가능하다. |
 |  10  | DATE          | DATE              |                                                              |
 |  11  | TIMESTAMP     | DATE              | 스케일의 차이로 인해서 소량의 데이터 손실이 발생할 수 있다. 오라클에서는 타임스탬프 값의 스케일이 나노초(9자리 수)인 반면, Altibase에서는 타임스탬프 값의 스케일이 마이크로초(6자리 수)이다. |
 |  12  | RAW           | BLOB              |                                                              |
@@ -1840,7 +1840,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |      | 원본          | 대상              | 주의 사항                                                    |
 | :--: | :------------ | :---------------- | :----------------------------------------------------------- |
 |  1   | BINARY        | BLOB              |                                                              |
-|  2   | BINARY_DOUBLE | VARCHAR(310)      |                                                              |
+|  2   | BINARY_DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 수행 중 손실이 가능하다. |
 |  3   | BINARY_FLOAT  | FLOAT             |                                                              |
 |  4   | BLOB          | BLOB              |                                                              |
 |  5   | CHAR          | CHAR              | Altibase의 CHAR 타입은 byte 길이로만 정의할 수 있기 때문에 TimesTen에서 문자 길이로 정의된 컬럼의 경우 자동으로 바이트 길이로 변환된다. |
@@ -1929,7 +1929,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 |  5   | LONG          | CLOB            |                                                              |
 |  6   | NUMBER        | NUMERIC         | 티베로에서 precision과 scale 없이 정의된 NUMBER 타입 컬럼은 Altibase에서도 동일하게 precision과 scale이 없는 NUMBER 타입으로 변환된다. \*참고: 티베로와 Altibase 모두 precision과 scale이 없는 NUMBER 타입으로 컬럼을 정의하면 데이터베이스 내부적으로 FLOAT 타입으로 처리한다. |
 |  7   | BINARY FLOAT  | FLOAT           |                                                              |
-|  8   | BINARY DOUBLE | VARCHAR(310)    | Altibase에는 티베로의 BINARY DOUBLE 타입과 호환되는 데이터 타입이 없으므로 데이터 손실을 막기 위해 문자형으로 저장된다. |
+|  8   | BINARY DOUBLE | DOUBLE          | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 수행 중 손실이 가능하다. |
 |  9   | DATE          | DATE            |                                                              |
 |  10  | TIME          | DATE            |                                                              |
 |  11  | TIMESTAMP     | DATE            | Scale의 차이로 인해서 소량의 데이터 손실이 발생할 수 있다. 티베로에서는 타임스탬프 값의 스케일이 나노초(9자리 수)인 반면, , Altibase에서는 타임스탬프 값의 scale이 마이크로초(6자리 수)이다. |


### PR DESCRIPTION
UX Migration Center 기본 데이터 타입 매핑 버그 BUG-49993 [ux-migrationCenter] 기본 데이터 타입 매핑에서 MySQL double data type은 알티베이스 double로 매핑해야 합니다. 에서 파생된 버그입니다.

Oracle의 BINARY_DOUBLE 타입을 알티베이스 double 타입으로 매핑할 수 있는지 상세 내용을 조사하여 변경 여부를 결정합니다.

- 원인: 알티베이스에는 Oracle의 BINARY_DOUBLE 타입과 호환되는 데이터 타입이 없다고 판단되어 데이터 손실을 막기 위해 문자형 VARCHAR로 매핑해왔으나 NaN, INF(Infinity)와 같이 특정 값을 제외하고 BINARY_DOUBLE의 표현 범위 내 값을 알티베이스 double 값으로 데이터 손실 없이 매핑이 가능할 것이라 예측되어 변경 전 검증이 필요합니다.
- 해결: Oracle의 BINARY_DOUBLE 데이터 타입을 Altibase DOUBLE로 매핑 가능함을 검증하였고, 테스트 케이스를 작성했습니다.

처음에는 Oracle Binary BINARY_DOUBLE -> Altibase double로 변경 작업에서 시작했습니다. 이후 Tibero, TimesTen도 거의 유사하기 때문에 함께 변경하는 것이 좋겠다는 의견을 내서 확장하게 되었습니다.
따라서, Oracle, Tibero, TimesTen BINARY_DOUBLE -> double 매핑 변경했고, 테스트 케이스에서는 기존 BinaryDoubleToVarchar 제거 및 BinaryDoubleToDouble 추가 작업을 수행했습니다.

해당 내용에 대해 매뉴얼 수정이 필요합니다.