### PR TITLE
BUG-50662

### DIFF
--- a/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
@@ -8385,7 +8385,7 @@ DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
   버전 4는 DICTIONARY에 대한 시스템 특권이 없다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
 
   ~~~sql
-  GRANT SELECT ANY TABLE TO USER_NAME;
+  GRANT SELECT ANY TABLE TO user_name;
   ~~~
 
 - Tibero 5 버전 이상
@@ -8393,7 +8393,7 @@ DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
   버전 5부터 SELECT ANY DICTIONARY 시스템 특권이 추가되었다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
 
   ~~~sql
-  GRANT SELECT ANY DICTIONARY TO USER_NAME;
+  GRANT SELECT ANY DICTIONARY TO user_name;
   ~~~
 
 `참고`

--- a/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
@@ -8374,15 +8374,15 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 
 `원인`
 
-마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 DICTIONARY 조회 권한이 없어 발생하는 오류이다.
+마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 DICTIONARY 조회 권한이 없어서 발생하는 오류이다.
 
 `해결 방법`
 
-DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
+DB 사용자 계정에 DICTIONARY 조회 권한을 부여한다.
 
 - Tibero 4 버전 이하
 
-  버전 4는 DICTIONARY에 대한 시스템 특권이 없다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
+  버전 4는 DICTIONARY에 대한 시스템 권한이 없으므로, SELECT ANY TABLE 권한을 부여한다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
 
   ~~~sql
   GRANT SELECT ANY TABLE TO user_name;
@@ -8390,7 +8390,7 @@ DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
 
 - Tibero 5 버전 이상
 
-  버전 5부터 SELECT ANY DICTIONARY 시스템 특권이 추가되었다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
+  SELECT ANY DICTIONARY 권한을 부여한다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
 
   ~~~sql
   GRANT SELECT ANY DICTIONARY TO user_name;

--- a/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
@@ -8374,24 +8374,26 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 
 `원인`
 
-마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 메타 정보 조회 권한이 없어 발생하는 오류이다.
+마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 DICTIONARY 조회 권한이 없어 발생하는 오류이다.
 
 `해결 방법`
 
-DB 사용자 계정에 메타 정보 조회 권한을 부여해 준다.
+DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
 
 - Tibero 4 버전 이하
 
+  버전 4는 DICTIONARY에 대한 시스템 특권이 없다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
+
   ~~~sql
-  GRANT SELECT ANY TABLE TO TEST_USER1;
+  GRANT SELECT ANY TABLE TO USER_NAME;
   ~~~
 
 - Tibero 5 버전 이상
 
-  SELECT ANY DICTIONARY 시스템 특권은 Tibero 5 버전부터 추가되었다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이고, SELECT ANY DICTIONARY는 DICTIONARY와 SYS, SYSCAT, SYSGIS 소유의 객체들을 조회할 수 있는 권한이다.
+  버전 5부터 SELECT ANY DICTIONARY 시스템 특권이 추가되었다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
 
   ~~~sql
-  GRANT SELECT ANY DICTIONARY TO TEST_USER1;
+  GRANT SELECT ANY DICTIONARY TO USER_NAME;
   ~~~
 
 `참고`

--- a/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
@@ -8370,15 +8370,15 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 
 ### Tibero
 
-#### 데이터베이스 연결 등록 및 수정 화면에서, "Test" 버튼 클릭 시 'Specified schema object was not found at: SELECT value FROM V$VERSION WHERE NAME = 'PRODUCT_MAJOR' OR NAME = 'TB_MAJOR' Please review your settings and correct any errors.'오류 메시지가 발생한다.
+#### 데이터베이스 연결 등록 및 수정 화면에서, "Test" 버튼 클릭 시 'Specified schema object was not found at: SELECT value FROM V$VERSION WHERE NAME = 'PRODUCT_MAJOR' OR NAME = 'TB_MAJOR' Please review your settings and correct any errors.' 오류 메시지가 발생한다.
 
 `원인`
 
-마이그레이션 접속 시 DB 버전 확인을 위한 메타 정보 수집 단계에서 접속에 사용된 DB 사용자 계정이 메타 정보 조회를 위한 충분한 권한이 없어 출력되는 메시지이다.
+마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 메타 정보 조회 권한이 없어 발생하는 오류이다.
 
 `해결 방법`
 
-마이그레이션 접속 시 메타 정보 조회를 위해 사용자 계정에 필요한 권한을 부여해준다.
+DB 사용자 계정에 메타 정보 조회 권한을 부여해 준다.
 
 - Tibero 4 버전 이하
 

--- a/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_release/kor/Migration Center User's Manual.md
@@ -168,12 +168,13 @@ Copyright ⓒ 2001~2023 Altibase Corp. All Rights Reserved.<br>
   - [표현 변환 규칙](#표현-변환-규칙)
 - [F.부록: FAQ](#f부록-faq)
   - [DBMS 공통](#dbms-공통)
-  - [Oracle](#oracle-1)
+  - [Oracle](#oracle-2)
   - [MS-SQL](#ms-sql)
-  - [Altibase](#altibase-1)
-  - [Informix](#informix-1)
-  - [MySQL](#mysql-1)
-  - [TimesTen](#timesten-1)
+  - [Altibase](#altibase-2)
+  - [Informix](#informix-2)
+  - [MySQL](#mysql-2)
+  - [TimesTen](#timesten-2)
+  - [Tibero](#Tibero-2)
 
 <br/>
 
@@ -8364,3 +8365,37 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 `해결 방법`
 
 마이그레이션 센터를 완전히 종료 후 재시작하여 데이터베이스 연결 등록을 하거나 연결 정보를 수정한다.
+
+<br/>
+
+### Tibero
+
+#### 데이터베이스 연결 등록 및 수정 화면에서, "Test" 버튼 클릭 시 'Specified schema object was not found at: SELECT value FROM V$VERSION WHERE NAME = 'PRODUCT_MAJOR' OR NAME = 'TB_MAJOR' Please review your settings and correct any errors.'오류 메시지가 발생한다.
+
+`원인`
+
+마이그레이션 접속 시 DB 버전 확인을 위한 메타 정보 수집 단계에서 접속에 사용된 DB 사용자 계정이 메타 정보 조회를 위한 충분한 권한이 없어 출력되는 메시지이다.
+
+`해결 방법`
+
+마이그레이션 접속 시 메타 정보 조회를 위해 사용자 계정에 필요한 권한을 부여해준다.
+
+- Tibero 4 버전 이하
+
+  ~~~sql
+  GRANT SELECT ANY TABLE TO TEST_USER1;
+  ~~~
+
+- Tibero 5 버전 이상
+
+  SELECT ANY DICTIONARY 시스템 특권은 Tibero 5 버전부터 추가되었다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이고, SELECT ANY DICTIONARY는 DICTIONARY와 SYS, SYSCAT, SYSGIS 소유의 객체들을 조회할 수 있는 권한이다.
+
+  ~~~sql
+  GRANT SELECT ANY DICTIONARY TO TEST_USER1;
+  ~~~
+
+`참고`
+
+- [https://www.tmaxtibero.com/img/service/pdf/manual/Tibero_4_SP1_Administrator's_Guide_v2.1.4.pdf](https://www.tmaxtibero.com/img/service/pdf/manual/Tibero_4_SP1_Administrator's_Guide_v2.1.4.pdf)
+- [https://technet.tmaxsoft.com/upload/download/online/tibero/pver-20220224-000002/tibero_admin/chapter_security.html#sect_so_privilege](https://technet.tmaxsoft.com/upload/download/online/tibero/pver-20220224-000002/tibero_admin/chapter_security.html#sect_so_privilege)
+

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -8378,15 +8378,15 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 
 `원인`
 
-마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 DICTIONARY 조회 권한이 없어 발생하는 오류이다.
+마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 DICTIONARY 조회 권한이 없어서 발생하는 오류이다.
 
 `해결 방법`
 
-DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
+DB 사용자 계정에 DICTIONARY 조회 권한을 부여한다.
 
 - Tibero 4 버전 이하
 
-  버전 4는 DICTIONARY에 대한 시스템 특권이 없다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
+  버전 4는 DICTIONARY에 대한 시스템 권한이 없으므로, SELECT ANY TABLE 권한을 부여한다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
 
   ~~~sql
   GRANT SELECT ANY TABLE TO user_name;
@@ -8394,7 +8394,7 @@ DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
 
 - Tibero 5 버전 이상
 
-  버전 5부터 SELECT ANY DICTIONARY 시스템 특권이 추가되었다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
+  SELECT ANY DICTIONARY 권한을 부여한다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
 
   ~~~sql
   GRANT SELECT ANY DICTIONARY TO user_name;

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -8374,15 +8374,15 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 
 ### Tibero
 
-#### 데이터베이스 연결 등록 및 수정 화면에서, "Test" 버튼 클릭 시 'Specified schema object was not found at: SELECT value FROM V$VERSION WHERE NAME = 'PRODUCT_MAJOR' OR NAME = 'TB_MAJOR' Please review your settings and correct any errors.'오류 메시지가 발생한다.
+#### 데이터베이스 연결 등록 및 수정 화면에서, "Test" 버튼 클릭 시 'Specified schema object was not found at: SELECT value FROM V$VERSION WHERE NAME = 'PRODUCT_MAJOR' OR NAME = 'TB_MAJOR' Please review your settings and correct any errors.' 오류 메시지가 발생한다.
 
 `원인`
 
-마이그레이션 접속 시 DB 버전 확인을 위한 메타 정보 수집 단계에서 접속에 사용된 DB 사용자 계정이 메타 정보 조회를 위한 충분한 권한이 없어 출력되는 메시지이다.
+마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 메타 정보 조회 권한이 없어 발생하는 오류이다.
 
 `해결 방법`
 
-마이그레이션 접속 시 메타 정보 조회를 위해 사용자 계정에 필요한 권한을 부여해준다.
+DB 사용자 계정에 메타 정보 조회 권한을 부여해 준다.
 
 - Tibero 4 버전 이하
 

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -169,13 +169,14 @@ Copyright ⓒ 2001~2023 Altibase Corp. All Rights Reserved.<br>
   - [표현 변환 규칙](#표현-변환-규칙)
 - [F.부록: FAQ](#f부록-faq)
   - [DBMS 공통](#dbms-공통)
-  - [Oracle](#oracle-1)
+  - [Oracle](#oracle-2)
   - [MS-SQL](#ms-sql)
-  - [Altibase](#altibase-1)
-  - [Informix](#informix-1)
-  - [MySQL](#mysql-1)
-  - [PostgreSQL](#postgresql-1)
-  - [TimesTen](#timesten-1)
+  - [Altibase](#altibase-2)
+  - [Informix](#informix-2)
+  - [MySQL](#mysql-2)
+  - [PostgreSQL](#postgresql-2)
+  - [TimesTen](#timesten-2)
+  - [Tibero](#Tibero-2)
 
 <br/>
 
@@ -8368,3 +8369,37 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 `해결 방법`
 
 마이그레이션 센터를 완전히 종료 후 재시작하여 데이터베이스 연결 등록을 하거나 연결 정보를 수정한다.
+
+<br/>
+
+### Tibero
+
+#### 데이터베이스 연결 등록 및 수정 화면에서, "Test" 버튼 클릭 시 'Specified schema object was not found at: SELECT value FROM V$VERSION WHERE NAME = 'PRODUCT_MAJOR' OR NAME = 'TB_MAJOR' Please review your settings and correct any errors.'오류 메시지가 발생한다.
+
+`원인`
+
+마이그레이션 접속 시 DB 버전 확인을 위한 메타 정보 수집 단계에서 접속에 사용된 DB 사용자 계정이 메타 정보 조회를 위한 충분한 권한이 없어 출력되는 메시지이다.
+
+`해결 방법`
+
+마이그레이션 접속 시 메타 정보 조회를 위해 사용자 계정에 필요한 권한을 부여해준다.
+
+- Tibero 4 버전 이하
+
+  ~~~sql
+  GRANT SELECT ANY TABLE TO TEST_USER1;
+  ~~~
+
+- Tibero 5 버전 이상
+
+  SELECT ANY DICTIONARY 시스템 특권은 Tibero 5 버전부터 추가되었다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이고, SELECT ANY DICTIONARY는 DICTIONARY와 SYS, SYSCAT, SYSGIS 소유의 객체들을 조회할 수 있는 권한이다.
+
+  ~~~sql
+  GRANT SELECT ANY DICTIONARY TO TEST_USER1;
+  ~~~
+
+`참고`
+
+- [https://www.tmaxtibero.com/img/service/pdf/manual/Tibero_4_SP1_Administrator's_Guide_v2.1.4.pdf](https://www.tmaxtibero.com/img/service/pdf/manual/Tibero_4_SP1_Administrator's_Guide_v2.1.4.pdf)
+- [https://technet.tmaxsoft.com/upload/download/online/tibero/pver-20220224-000002/tibero_admin/chapter_security.html#sect_so_privilege](https://technet.tmaxsoft.com/upload/download/online/tibero/pver-20220224-000002/tibero_admin/chapter_security.html#sect_so_privilege)
+

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -8389,7 +8389,7 @@ DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
   버전 4는 DICTIONARY에 대한 시스템 특권이 없다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
 
   ~~~sql
-  GRANT SELECT ANY TABLE TO USER_NAME;
+  GRANT SELECT ANY TABLE TO user_name;
   ~~~
 
 - Tibero 5 버전 이상
@@ -8397,7 +8397,7 @@ DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
   버전 5부터 SELECT ANY DICTIONARY 시스템 특권이 추가되었다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
 
   ~~~sql
-  GRANT SELECT ANY DICTIONARY TO USER_NAME;
+  GRANT SELECT ANY DICTIONARY TO user_name;
   ~~~
 
 `참고`

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -8378,24 +8378,26 @@ Native library를 사용하는 TimesTen type 2 JDBC driver를 로딩한 상태�
 
 `원인`
 
-마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 메타 정보 조회 권한이 없어 발생하는 오류이다.
+마이그레이션 센터 접속에 사용된 DB 사용자 계정이 DB 버전 확인을 위한 DICTIONARY 조회 권한이 없어 발생하는 오류이다.
 
 `해결 방법`
 
-DB 사용자 계정에 메타 정보 조회 권한을 부여해 준다.
+DB 사용자 계정에 DICTIONARY 조회 권한을 부여해 준다.
 
 - Tibero 4 버전 이하
 
+  버전 4는 DICTIONARY에 대한 시스템 특권이 없다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이다.
+
   ~~~sql
-  GRANT SELECT ANY TABLE TO TEST_USER1;
+  GRANT SELECT ANY TABLE TO USER_NAME;
   ~~~
 
 - Tibero 5 버전 이상
 
-  SELECT ANY DICTIONARY 시스템 특권은 Tibero 5 버전부터 추가되었다. SELECT ANY TABLE은 임의의 스키마에 속한 객체들을 조회할 수 있는 권한이고, SELECT ANY DICTIONARY는 DICTIONARY와 SYS, SYSCAT, SYSGIS 소유의 객체들을 조회할 수 있는 권한이다.
+  버전 5부터 SELECT ANY DICTIONARY 시스템 특권이 추가되었다. SELECT ANY DICTIONARY는 SYS, SYSCAT, SYSGIS 소유의 객체(DICTIONARY)를 조회할 수 있는 권한이다.
 
   ~~~sql
-  GRANT SELECT ANY DICTIONARY TO TEST_USER1;
+  GRANT SELECT ANY DICTIONARY TO USER_NAME;
   ~~~
 
 `참고`


### PR DESCRIPTION
[INC-48244]에서 파생된 버그입니다. Migration Center 접속 시 Tibero 접속 성공 이후, DB 버전 확인을 위한 메타 정보 수집 단계에서 스키마 조회 실패 에러가 발생하였습니다.

마이그레이션을 위해 메타 정보 수집은 필수이기 때문에 접속에 사용된 DB 사용자 계정이 메타 정보 조회를 위한 충분한 권한을 가지고 있는지 확인이 필요합니다.

- 원인: 마이그레이션 접속 시 DB 버전 확인을 위한 메타 정보 수집 단계에서 접속에 사용된 DB 사용자 계정이 메타 정보 조회를 위한 충분한 권한이 없어 에러가 발생합니다.

- 해결: 마이그레이션 접속 시 메타 정보 조회를 위해 사용자 계정에 필요한 권한을 조사하였고, 변경 결과 테스트 통과하였습니다.

다만, 해결 방법으로 처음 제시되었던 SELECT ANY DICTIONARY 시스템 특권은 티베로 4버전 이하에서는 존재하지 않았음을 확인하였습니다. 따라서 4버전 이하에서는 SELECT ANY TABLE 특권을 대신 부여해 주어야 합니다.

해당 내용에 대해 매뉴얼 수정이 필요합니다.