### PR TITLE
BUG-50577

### DIFF
--- a/Manuals/Tools/Altibase_release/eng/Altibase 3rd Party Connector Guide.md
+++ b/Manuals/Tools/Altibase_release/eng/Altibase 3rd Party Connector Guide.md
@@ -229,9 +229,10 @@ Altibase Plugin is not an official plugin for SQuirreL SQL Client, so users must
 
 This is the list of the software and system requirements to install and run the Altibase plugin and the database management system.
 
-| Software Requirements      | SQuirreL SQL Client 3.7.1 or 3.8.0 |
-| -------------------------- | ---------------------------------- |
-| Compatible Database System | Altibase 6.5.1 or later            |
+| Software Requirements      | SQuirreL SQL Client 3.7.1 or 3.8.0 | SQuirreL SQL Client 3.8.1 or 3.9.0 |
+| -------------------------- | ---------------------------------- | ---------------------------------- |
+| Compatible Database System | Altibase 6.5.1 or later            | Altibase 6.5.1 or later            |
+| Compatible Java            | Java 1.8.0                         | Java 1.8.0 or later                |
 
 ### Installing and Removing Altibase Plugin
 
@@ -378,6 +379,8 @@ This error occurs because the SQuirreL SQL client does not recognize the latest 
 Find the JavaVersionChecker line in the squirrel-sql.bat or squirrel-sql.sh file and add the version to use. For example, when using OpenJDK 18 version, add '18' at the end of the JavaVersionChecker line and save it, then run the SQuirreL SQL client.
 
 `$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 1.6 1.7 1.8 18`
+
+If you use Java version 9 or later, SQuirreL SQL client version 3.8.1 or 3.9.0 is required.
 
 Please refer to https://sourceforge.net/p/squirrel-sql/bugs/1347/
 

--- a/Manuals/Tools/Altibase_release/kor/Altibase 3rd Party Connector Guide.md
+++ b/Manuals/Tools/Altibase_release/kor/Altibase 3rd Party Connector Guide.md
@@ -374,9 +374,10 @@ SQuirreL SQL Client의 공식 Plugin이 아니기 때문에, SQuirreL SQL Client
 Altibase plugin을 설치하고 실행하기 위해 필요한 소프트웨어 요구사항과 Altibase
 Plugin과 호환되는 데이터베이스 관리 시스템을 열거한다.
 
-| 소프트웨어 요구사항        | SQuirreL SQL Client 3.7.1 또는 3.8.0 |
-| ----------------- | ---------------------------------- |
-| 호환 가능한 데이터베이스 시스템 | Altibase 6.5.1 또는 그 이상의 버전         |
+| 소프트웨어 요구사항             | SQuirreL SQL Client 3.7.1 또는 3.8.0 | SQuirreL SQL Client 3.8.1 또는 3.9.0 |
+| ------------------------------- | ------------------------------------ | ------------------------------------ |
+| 호환 가능한 데이터베이스 시스템 | Altibase 6.5.1 또는 그 이상의 버전   | Altibase 6.5.1 또는 그 이상의 버전   |
+| 호환 가능한 Java                | Java 1.8.0                           | Java 1.8.0 또는 그 이상의 버전       |
 
 ### Altibase Plugin 설치 및 제거
 
@@ -547,6 +548,8 @@ SQuirreL SQL 클라이언트가 최신 Java 버전을 인지하지 못해 발생
 squirrel-sql.bat 또는 squirrel-sql.sh 파일에서 JavaVersionChecker 라인을 찾아 사용할 JDK 버전을 추가한다. 예를 들어 OpenJDK 18 버전을 사용할 경우, JavaVersionChecker 라인 끝에 18을 추가 및 저장 후, SQuirreL SQL 클라이언트를 수행하면 정상적으로 구동된다. 
 
 `$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 1.6 1.7 1.8 18`
+
+다만 Java 9 버전 이상을 사용할 경우 SQuirreL SQL 클라이언트 3.8.1 또는 3.9.0 버전을 설치해야 한다.
 
 참조: https://sourceforge.net/p/squirrel-sql/bugs/1347/
 

--- a/Manuals/Tools/Altibase_trunk/eng/Altibase 3rd Party Connector Guide.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Altibase 3rd Party Connector Guide.md
@@ -231,9 +231,10 @@ Altibase Plugin is not an official plugin for SQuirreL SQL Client, so users must
 
 This is the list of the software and system requirements to install and run the Altibase plugin and the database management system.
 
-| Software Requirements      | SQuirreL SQL Client 3.7.1 or 3.8.0 |
-| -------------------------- | ---------------------------------- |
-| Compatible Database System | Altibase 6.5.1 or later            |
+| Software Requirements      | SQuirreL SQL Client 3.7.1 or 3.8.0 | SQuirreL SQL Client 3.8.1 or 3.9.0 |
+| -------------------------- | ---------------------------------- | ---------------------------------- |
+| Compatible Database System | Altibase 6.5.1 or later            | Altibase 6.5.1 or later            |
+| Compatible Java            | Java 1.8.0                         | Java 1.8.0 or later                |
 
 ### Installing and Removing Altibase Plugin
 
@@ -380,6 +381,8 @@ This error occurs because the SQuirreL SQL client does not recognize the latest 
 Find the JavaVersionChecker line in the squirrel-sql.bat or squirrel-sql.sh file and add the version to use. For example, when using OpenJDK 18 version, add '18' at the end of the JavaVersionChecker line and save it, then run the SQuirreL SQL client.
 
 `$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 1.6 1.7 1.8 18`
+
+If you use Java version 8 or later, SQuirreL SQL client version 3.8.1 or 3.9.0 is required.
 
 Please refer to https://sourceforge.net/p/squirrel-sql/bugs/1347/
 

--- a/Manuals/Tools/Altibase_trunk/eng/Altibase 3rd Party Connector Guide.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Altibase 3rd Party Connector Guide.md
@@ -382,7 +382,7 @@ Find the JavaVersionChecker line in the squirrel-sql.bat or squirrel-sql.sh file
 
 `$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 1.6 1.7 1.8 18`
 
-If you use Java version 8 or later, SQuirreL SQL client version 3.8.1 or 3.9.0 is required.
+If you use Java version 9 or later, SQuirreL SQL client version 3.8.1 or 3.9.0 is required.
 
 Please refer to https://sourceforge.net/p/squirrel-sql/bugs/1347/
 

--- a/Manuals/Tools/Altibase_trunk/kor/Altibase 3rd Party Connector Guide.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Altibase 3rd Party Connector Guide.md
@@ -549,7 +549,7 @@ squirrel-sql.bat 또는 squirrel-sql.sh 파일에서 JavaVersionChecker 라인�
 
 `$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 1.6 1.7 1.8 18`
 
-다만 Java 8 버전 이상을 사용할 경우 SQuirreL SQL 클라이언트 3.8.1 또는 3.9.0 버전을 설치해야 한다.
+다만 Java 9 버전 이상을 사용할 경우 SQuirreL SQL 클라이언트 3.8.1 또는 3.9.0 버전을 설치해야 한다.
 
 참조: https://sourceforge.net/p/squirrel-sql/bugs/1347/
 

--- a/Manuals/Tools/Altibase_trunk/kor/Altibase 3rd Party Connector Guide.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Altibase 3rd Party Connector Guide.md
@@ -374,9 +374,10 @@ SQuirreL SQL Client의 공식 Plugin이 아니기 때문에, SQuirreL SQL Client
 Altibase plugin을 설치하고 실행하기 위해 필요한 소프트웨어 요구사항과 Altibase
 Plugin과 호환되는 데이터베이스 관리 시스템을 열거한다.
 
-| 소프트웨어 요구사항        | SQuirreL SQL Client 3.7.1 또는 3.8.0 |
-| ----------------- | ---------------------------------- |
-| 호환 가능한 데이터베이스 시스템 | Altibase 6.5.1 또는 그 이상의 버전         |
+| 소프트웨어 요구사항             | SQuirreL SQL Client 3.7.1 또는 3.8.0 | SQuirreL SQL Client 3.8.1 또는 3.9.0 |
+| ------------------------------- | ------------------------------------ | ------------------------------------ |
+| 호환 가능한 데이터베이스 시스템 | Altibase 6.5.1 또는 그 이상의 버전   | Altibase 6.5.1 또는 그 이상의 버전   |
+| 호환 가능한 Java                | Java 1.8.0                           | Java 1.8.0 또는 그 이상의 버전       |
 
 ### Altibase Plugin 설치 및 제거
 
@@ -547,6 +548,8 @@ SQuirreL SQL 클라이언트가 최신 Java 버전을 인지하지 못해 발생
 squirrel-sql.bat 또는 squirrel-sql.sh 파일에서 JavaVersionChecker 라인을 찾아 사용할 JDK 버전을 추가한다. 예를 들어 OpenJDK 18 버전을 사용할 경우, JavaVersionChecker 라인 끝에 18을 추가 및 저장 후, SQuirreL SQL 클라이언트를 수행하면 정상적으로 구동된다. 
 
 `$JAVACMD -cp "$UNIX_STYLE_HOME/lib/versioncheck.jar" JavaVersionChecker 1.6 1.7 1.8 18`
+
+다만 Java 8 버전 이상을 사용할 경우 SQuirreL SQL 클라이언트 3.8.1 또는 3.9.0 버전을 설치해야 한다.
 
 참조: https://sourceforge.net/p/squirrel-sql/bugs/1347/
 


### PR DESCRIPTION
BUG-50572 [ux-squirrelSql] Squirrel4Altibase 730 호환성 테스트 중 발견된 버그입니다.
최신 Java 버전 사용 시 SQuirreL SQL 구동 에러가 발생한 것에서 시작하였습니다. 해당 오류는 FAQ에 기재된 내용대로 해결이 가능합니다.
하지만 특정 SQuirreL SQL 버전에서 알티베이스 플러그인 적용 시 구동 에러, JRE 버전에 따라 클라이언트 빌드 에러가 발생합니다.
따라서 알티베이스 플러그인과 호환되는 SQuirreL SQL 버전 및 Java 버전 확인이 필요합니다.

- 원인: 매뉴얼에 기재된 SQuirreL SQL 버전 요구사항 3.7.1 또는 3.8.0 버전은 Java 8 상위 버전 환경에서 구동 시 jaxb API 참조를 실패하여 에러가 발생합니다. (Java 9 버전부터 jaxb API가 Java SE에서 EE로 옮겨졌고, 버전 11부터 완전히 제거되었기 때문에 발생하는 오류입니다. [참고](https://openjdk.org/jeps/320)) SQuirreL SQL 3.9.1 버전부터는 altibase 플러그인이 정상적으로 동작하지 않습니다.

- 해결: Java 8 버전을 사용한다면 기존 요구사항인 SQuirreL SQL  3.7.1 또는 3.8.0 버전 사용이 가능합니다. Java 9 버전 이상 사용 시 SQuirreL SQL 3.8.1 또는 3.9.0 버전에서 에러 없이 정상적으로 구동 가능합니다. 그 외 버전에서는 사용할 수 없습니다.

해당 내용에 대해 매뉴얼 수정이 필요합니다.
