### PR TITLE
Spatial Data Type related Manuals Update

### DIFF
--- a/Manuals/Altibase_7.3/eng/Spatial SQL Reference.md
+++ b/Manuals/Altibase_7.3/eng/Spatial SQL Reference.md
@@ -867,7 +867,7 @@ INSERT INTO test1 VALUES (6, GEOMCOLLFROMTEXT('GEOMETRYCOLLECTION EMPTY'));
 
 In Altibase, the GEOMETRY data type can be represented using any of the three ways described below:
 
--   WKT (Well-Known Text): A text format in which a spatial object is represented using letters and numbers. This allows it to be processed directly within SQL applications or other similar applications. The WKT format was designed using simple gramar for easy readability. 
+-   WKT (Well-Known Text): A text format in which a spatial object is represented using letters and numbers. This allows it to be processed directly within SQL applications or other similar applications. The WKT format was designed using simple grammar for easy readability. 
 -   WKB (Well-Known Binary): A format in which a spatial object is represented in binary form. It was designed for the purpose of efficiently transferring and performing operations on GEOMETRY type data.
 -   EWKT(Extended Well-Known Text) format: A text format in which Spatial Reference Identifier (SRID) information representing spatial objects has been added to the WKT format.
 -   EWKB(Extended Well-Known Binary) format: A text format in which Spatial Reference Identifier (SRID) information representing spatial objects is added to the WKB format
@@ -1192,9 +1192,8 @@ AThe spatial functions that are available in Altibase can be broadly classified 
 -   Spatial Analysis Functions  
     These functions are used to perform various analytical tasks on GEOMETRY type data.
 
-    Spatial Object Creationg Functions  
-    These functions are used to create spatial objects in WKT or WKB format, rather than in the internal storage format of Altibase.
-    
+-   Spatial Object Creation Functions  
+    These functions are used to create spatial objects in WKT, WKB, EWKT, or EWKB format, rather than in the internal storage format of Altibase.
 
 ### Basic Spatial Functions
 
@@ -3012,7 +3011,7 @@ F1          SRID(F2)
 ##### Syntax
 
 ```
-GEOMFROMTEXT( WKT)
+GEOMFROMTEXT( WKT[, srid])
 ```
 
 ##### Description
@@ -3023,7 +3022,7 @@ This function accepts a description of a spatial object in WKT (Well-known Text)
 
 The input can be any type of spatial object that can be described using WKT. If the syntax of the input WKT is not valid, this function outputs an error.
 
-The SIRD of the created object is 0.
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Value
 
@@ -3048,6 +3047,12 @@ GEOMETRYCOLLECTION( POINT(10 10) , POINT(30 30) , LINESTRING(15 15, 20 20) )
 
 iSQL> INSERT INTO TB3 VALUES (102, GEOMFROMTEXT('POLYGON((10 10, 10 20, 20 20, 20 15, 10))'));
 [ERR-A101A : Parsing error of well-known-text]
+
+iSQL> SELECT ASEWKT(GEOMFROMTEXT('POINT(1 1)', 100)) AS OBJ FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;POINT(1 1)
+1 row selected.
 ```
 
 #### POINTFROMTEXT
@@ -3055,7 +3060,7 @@ iSQL> INSERT INTO TB3 VALUES (102, GEOMFROMTEXT('POLYGON((10 10, 10 20, 20 20, 2
 ##### Syntax
 
 ```
-POINTFROMTEXT( WKT)
+POINTFROMTEXT( WKT[, srid] )
 ```
 
 ##### Description
@@ -3066,7 +3071,7 @@ If the syntax of the input WKT is not valid, or if the WKT describes a GEOMETRY 
 
 This function returns NULL if the value of the WKT argument is NULL.
 
-The SIRD of the created object is 0. 
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3090,6 +3095,12 @@ POINT(10 10)
 
 iSQL> INSERT INTO TB3 VALUES (103, POINTFROMTEXT('GEOMETRYCOLLECTION( POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))'));
 [ERR-A1019 : Not applicable object type]
+
+iSQL> SELECT ASEWKT(POINTFROMTEXT('POINT(1 1)', 100)) AS OBJ FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;POINT(1 1)
+1 row selected.
 ```
 
 #### LINEFROMTEXT 
@@ -3097,7 +3108,7 @@ iSQL> INSERT INTO TB3 VALUES (103, POINTFROMTEXT('GEOMETRYCOLLECTION( POINT(10 1
 ##### Syntax
 
 ```
-LINEFROMTEXT( WKT )
+LINEFROMTEXT( WKT[, srid] )
 ```
 
 ##### Description
@@ -3108,7 +3119,7 @@ If the syntax of the input WKT is not valid, or if the WKT describes a GEOMETRY 
 
 This function returns NULL if the value of the WKT argument is NULL.
 
-The SIRD of the created object is 0. 
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3132,6 +3143,12 @@ LINESTRING(10 10, 20 20, 30 40)
 
 iSQL> INSERT INTO TB3 VALUES (104, LINEFROMTEXT('MULTIPOLYGON(((10 10, 10 20, 20 20, 20 15, 10 10)), ((60 60, 70 70, 80 60, 60 60)))'));
 [ERR-A1019 : Not applicable object type]
+
+iSQL> SELECT ASEWKT(LINEFROMTEXT('LINESTRING(10 10, 20 20, 30 40)', 100) ) FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;LINESTRING(10 10, 20 20, 30 40)
+1 row selected.
 ```
 
 #### POLYFROMTEXT
@@ -3150,7 +3167,7 @@ If the syntax of the input WKT is not valid, or if the WKT describes a GEOMETRY 
 
 This function returns NULL if the value of the WKT argument is NULL.
 
-The SRID of a created object is 0.
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3185,6 +3202,11 @@ ID          ASEWKT(OBJ)
 120         SRID=100;POLYGON((10 10, 10 20, 20 20, 20 15, 10 10))
 2 rows selected.
 
+iSQL> SELECT ASEWKT(POLYFROMTEXT('POLYGON((10 10, 10 20, 20 20, 20 15, 10 10))', 100)) AS OBJ FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;POLYGON((10 10, 10 20, 20 20, 20 15, 10 10))
+1 row selected.
 ```
 
 #### ST_POLYGONFROMTEXT
@@ -3240,7 +3262,7 @@ ID          ASEWKT(OBJ)
 ##### Syntax
 
 ```
-MPOINTFROMTEXT( WKT )
+MPOINTFROMTEXT( WKT[, srid] )
 ```
 
 ##### Description
@@ -3251,7 +3273,7 @@ If the syntax of the input WKT is not valid, or if the WKT describes a GEOMETRY 
 
 This function returns NULL if the value of the WKT argument is NULL.
 
-The SRID of a created object is 0.
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3275,6 +3297,13 @@ MULTIPOINT(10 10, 20 20)
 
 iSQL> INSERT INTO TB3 VALUES (106, MPOINTFROMTEXT('LINESTRING(10 10, 20 20, 30 40)'));
 [ERR-A1019 : Not applicable object type]
+
+
+iSQL> SELECT ASEWKT( MPOINTFROMTEXT('MULTIPOINT(10 10, 20 20)', 100) ) AS OBJ FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;MULTIPOINT(10 10, 20 20)
+1 row selected.
 ```
 
 #### MLINEFROMTEXT
@@ -3282,7 +3311,7 @@ iSQL> INSERT INTO TB3 VALUES (106, MPOINTFROMTEXT('LINESTRING(10 10, 20 20, 30 4
 ##### Syntax
 
 ```
-MLINEFROMTEXT( WKT )
+MLINEFROMTEXT( WKT[, srid] )
 ```
 
 ##### Description
@@ -3293,7 +3322,7 @@ This function accepts a spatial object in WKT (Well-known Text) format as input 
 
  This function returns NULL if the value of the WKT argument is NULL.
 
-The SRID of a created object is 0.
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3316,6 +3345,13 @@ MULTILINESTRING((10 10, 20 20), (15 15, 30 15))
 1 row selected.
 iSQL> INSERT INTO TB3 VALUES (107, MLINEFROMTEXT('POINT(10 10)'));
 [ERR-A1019 : Not applicable object type]
+
+
+iSQL> SELECT ASEWKT(MLINEFROMTEXT('MULTILINESTRING((10 10, 20 20), (15 15, 30 15))', 100))AS OBJ FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;MULTILINESTRING((10 10, 20 20), (15 15, 30 15))
+1 row selected.
 ```
 
 #### MPOLYFROMTEXT
@@ -3323,7 +3359,7 @@ iSQL> INSERT INTO TB3 VALUES (107, MLINEFROMTEXT('POINT(10 10)'));
 ##### Syntax
 
 ```
-MPOLYFROMTEXT( WKT )
+MPOLYFROMTEXT( WKT[, srid] )
 ```
 
 ##### Description
@@ -3333,6 +3369,8 @@ This function accepts a spatial object in WKT (Well-known Text) format as input 
 If the syntax of the input WKT is not valid, or if the WKT describes a GEOMETRY subtype other than a MULTIPOLYGON object, this function outputs an error. 
 
 This function returns NULL if the value of the WKT argument is NULL.
+
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3356,6 +3394,13 @@ MULTIPOLYGON(((10 10, 10 20, 20 20, 20 15, 10 10)), ((60 60, 70 70, 80 60, 60 60
 
 iSQL> INSERT INTO TB3 VALUES (108, MPOLYFROMTEXT('MULTIPOINT(10 10, 20 20)'));
 [ERR-A1019 : Not applicable object type]
+
+
+iSQL> SELECT ASEWKT(MPOLYFROMTEXT('MULTIPOLYGON(((10 10, 10 20, 20 20, 20 15, 10 10)), ((60 60, 70 70, 80 60, 60 60)))',100)) AS OBJ FROM DUAL;
+OBJ
+-------------------------------------
+SRID=100;MULTIPOLYGON(((10 10, 10 20, 20 20, 20 15, 10 10)), ((60 60, 70 70, 80 60, 60 60)))
+1 row selected.
 ```
 
 #### GEOMCOLLFROMTEXT
@@ -3363,7 +3408,7 @@ iSQL> INSERT INTO TB3 VALUES (108, MPOLYFROMTEXT('MULTIPOINT(10 10, 20 20)'));
 ##### Syntax
 
 ```
-GEOMCOLLFROMTEXT( WKT )
+GEOMCOLLFROMTEXT( WKT[, srid] )
 ```
 
 ##### Description
@@ -3373,6 +3418,8 @@ This function accepts a spatial object in WKT (Well-known Text) format as input 
 If the syntax of the input WKT is not valid, or if the WKT describes a GEOMETRY subtype other than a GEOMETRYCOLLECTION, this function outputs an error. 
 
 This function returns NULL if the value of the WKT argument is NULL.
+
+Users can set SRID during the creation of this object. Without any specific setting, the SRID of the created object is 0.
 
 ##### Return Type
 
@@ -3398,6 +3445,12 @@ GEOMETRYCOLLECTION( POINT(10 10) , POINT(30 30) , LINESTRING(15 15, 20 20) )
 
 iSQL> INSERT INTO TB3 VALUES (109, GEOMCOLLFROMTEXT('POLYGON((10 10, 10 20, 20 20, 20 15, 10 10))'));
 [ERR-A1019 : Not applicable object type]
+
+iSQL> SELECT ASEWKT(GEOMCOLLFROMTEXT('GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))',100)) AS OBJ FROM DUAL;
+OBJ
+---------------------------------------------
+SRID=100;GEOMETRYCOLLECTION( POINT(10 10) , POINT(30 30) , LINESTRING(15 15, 20 20) )
+1 row selected.
 ```
 
 #### ST_GEOMETRY
@@ -6837,7 +6890,19 @@ else
 
 ```
 
-# Appendix A. Limitations on the Use of Spatial Data in Altiabase
+# 4. Spatial Data Migration
+
+This section describes how to migrate spatial data between Atibase products or other vendor database products.
+
+### Spatial Data Migration Between Altibase Products
+
+For the migration of spatial data between Altibase products, iLoader and aexport can be utilized. Both utilities support spatial data types.
+
+One important consideration is the storage format for spatial data in Altibase. Based on the metadata version of the SYSTEM_.SYS_DATABASE_ table, versions below 8.8.1 support the WKB format, while versions 8.8.1 and above support the EWKB format. During migration, the extracted spatial data format follows the format of the Altibase where the spatial data is stored. Consequently, versions below 8.8.1 generate WKB format spatial data files, and versions 8.8.1 and above create EWKB format data files.
+
+Spatial data in WKB format is automatically recognized and converted by Altibase supporting EWKB. However, Altibase supporting WKB cannot recognize spatial data in EWKB format. Therefore, when transferring EWKB format data to an Altibase supporting WKB, the option to extract the original data in WKB format must be used. During migration tasks, use the 'ILOADER_GEOM = WKB' option in the aexport.properties file for aexport, and for a single table operation, use the '-geom WKB' option in iLoader. For detailed information, please refer to the iLoader and aexport manuals.
+
+# Appendix A. Limitations on the Use of Spatial Data in Altibase
 
 With the expansion of Altibase into the realm of spatial data, inevitably some of Altibase's extensive functionality lacks support for use with spatial data. The current limitations are explained in detail in this Appendix.
 

--- a/Manuals/Altibase_7.3/eng/Utilities Manual.md
+++ b/Manuals/Altibase_7.3/eng/Utilities Manual.md
@@ -693,102 +693,133 @@ When Altibase is installed, the \$ALTIBASE_HOME/conf directory does not actually
     OPERATION = IN/OUT  
     If this property is set to OUT, scripts for exporting all schemas and data will be created. When the data export script, which consists of iLoader commands, is executed, form files (.fmt) and data files (.dat) will be created.  
     If this property is set to IN, the schema creation script and the data loading script, which were created by previously executing aexport with this property set to OUT, will be executed, the schema will be created in the destination database, and the data will be loaded into the destination database. The schema creation script and the data loading script can be executed manually at a shell prompt without executing aexport.
+    
 -   EXECUTE  
     This property determines whether to automatically execute the scripts that were created.  
     EXECUTE = ON/OFF  
     If it is set to ON, the scripts that are appropriate for the current operation (set using the OPERATION property) will be executed automatically. The file names of these scripts are set using the ILOADER_OUT, ILOADER_IN, ISQL, ISQL_CON, ISQL_INDEX, ISQL_FOREIGN_KEY, ISQL_ALT_TBL, and ISQL_REPL properties.  
     If it is set to OFF, the scripts will be created, but not executed.
+    
 -   INVALID_SCRIPT  
     This property determines whether to group all of the object creation scripts for invalid objects in a single script file.  
     INVALID_SCRIPT = ON/OFF  
     If this property is set to OFF, a SQL script file will be generated for each of the invalid objects in the database; that is, they will be treated just like the valid database objects.
+    
 -   TWO_PHASE_SCRIPT  
     This property determines whether to group all of the object creation scripts in two script files.  
     TWO_PHASE_SCRIPT = ON/OFF  
     If this property is set to ON, aexport will create only two SQL script files and two shell script files: ALL_OBJECT.sql, ALL_OBJECT_CONSTRAINS.sql, ALL_OBJECT.sql, run_is.sh, run_is_con.sh  
     If this property is set to OFF, aexport will generate different SQL script files for each of the objects in a database.
+    
 -   CRT_TBS_USER_MODE  
     CRT_TBS_USER_MODE = ON/OFF (Default: OFF)  
     This property determines whether or not to extract a statement for creating tablespace in user mode.  
     If this property is set to ON, the SQL statement creating tablespace related to the user in the user mode is extracted. The user related tablespaces are default tablespace, default temporary tablespace, and the tablespace specified whether or not to available to be accessed.
+    
 -   INDEX  
     INDEX = ON/OFF  
     This property determines whether or not to create the indexes when creating the rest of the schema in the destination database. If it is desired to create the indexes after the data have been located into the destination database, set this property to ON. It is used when the TWO_PHASE_SCRIPT property is set to OFF.
+    
 -   USER_PASSWORD  
     USER_PASSWORD = *password*  
     This property is used to set the password when the users exported from the source database are created in the destination database. (Because aexport does not know the passwords of users exported from the source database, the passwords must be manually set.) If this property is not set, a prompt for setting each user's password will appear.
+    
 -   VIEW_FORCE  
     VIEW_FORCE = ON/OFF  
     If this property is set to ON, views will be forcibly created, even if the underlying tables or other objects don't exist.
+    
 -   DROP  
     This property determines whether to include DROP statements in created scripts.  
     DROP = ON/OFF  
     If this property is set to ON, and if the destination database already contains objects corresponding to those that are to be created, the existing objects will be dropped. Because this option specifies that existing objects are to be dropped, it should be used with caution.  
     Note) If aexport is executed in Object Mode, DROP statements are not generated, regardless of the setting of this property.
+    
 -   ILOADER_OUT  
     ILOADER_OUT = *run_il_out.sh*  
     This property determines the name of the shell script file that is created to export (download) the data from the source database. It is used when the OPERATION property is set to OUT.
+    
 -   ILOADER_IN  
     ILOADER_IN = *run_il_in.sh*  
     This property determines the name of the shell script file that will be used to import (upload) the data into the destination database.
+    
 -   ISQL  
     ISQL = *run_is.sh*  
     This property determines the name of the script file that will be used to create the database schema in the destination database.
+    
 -   ISQL_CON  
     ISQL\_ CON = *run_is_con.sh*  
     This property determines the name of the shell script file that is used to execute the SQL script files for creating indexes, foreign keys, triggers and replication objects. It is used when the TWO_PHASE_SCRIPT property is set to ON.
+    
 -   ISQL_INDEX  
     ISQL_INDEX = *run_is_index.sh*  
     This property determines the name of the shell script that will be used to create indexes in the destination database. If no value is specified for this property in the aexport.properties file, this shell script file will not be generated.
+    
 -   ISQL_FOREIGN_KEY  
     ISQL\_ FOREIGN_KEY = *run_is_fk.sh*  
     This property determines the name of the shell script file that is used to execute the SQL script files for creating foreign keys. If no value is specified for this property in the aexport.properties file, this shell script file will not be generated.
+    
 -   ISQL_REPL  
     ISQL_REPL = *run_is_repl.sh*  
     This property determines the name of the shell script that will be used to create replication objects in the destination database. If no value is specified for this property in the aexport.properties file, this shell script file will not be generated.
+    
 -   COLLECT_DBMS_STATS  
     This property determines whether to display the statistics for tables, columns and indexes of specified user.  
     COLLECT_DBMS_STATS = ON/OFF  
     The default value is OFF and no statistical information is exported. When this property's value is ON, statistics information is exported.
+    
 -   ISQL_REFERSH_MVIEW  
     ISQL_REFERSH_MVIEW = *run_is_refresh_mview.sh*  
     This property determines the name of the shell script that will be used to execute the SQL script files for refreshing the materialized view in the destination database. If no value is specified for this property in the aexport.properties file, this shell script file will not be generated.
+    
 -   ISQL_ALT_TBL  
     ISQL_ALT_TBL = *run_is_alt_tbl.sh*  
     This property sets the name of the shell script file executing the SQL script which switches the data access mode for the tables and partitions of the target database. On omission, aexport does not generate this shell script file.
+    
 -   ILOADER_FIELD_TERM  
     ILOADER_FIELD_TERM = *field_term*  
     This property is used to set the field delimiters that are used when the data in tables are saved as text. If this property is not set, the default delimiter between values is the comma (“,”), no block delimiters are used for numeric values, and double quotation marks (“ “ “) are used as block delimiters around strings.  
     Note) The pound (i.e. hash or number sign) character “#” cannot be specified as a delimiter, because it is used to denote comments in the properties file (The remainder of the line after the “#” will be ignored).
+    
 -   ILOADER_ROW_TERM  
     ILOADER\_ ROW \_TERM = *row_term*  
     This property sets the record delimiter to use wwhen texting table data. If not set, the default is <LF\>.  
     Note) The pound (i.e. hash or number sign) character “#” cannot be specified as the record delimiter, because it is used to denote comments in the properties file (The remainder of the line after the “#” will be ignored).
+    
 -   ILOADER_PARTITION  
     This property determines whether or not to create SQL scripts and shell scripts for creating partitions.  
     ILOADER\_ PARTITION = ON/OFF  
     If this property is set to ON, shell scripts for exporting data from partitions, for creating partitioned tables and all of their partitions, and for importing data into each partition are generated. In other words, enabling this property makes it possible to import data from table partitions in the source database into corresponding partitions in partitioned tables in the destination database.  If this property is set to OFF, whether tables in the source database are partitioned is ignored, and the shell script that is generated creates non-partitioned tables in the destination database and imports data from all partitions of partitioned tables in the source database into corresponding non-partitioned tables in the destination database.  
         For more detailed infomraiton, please refer to the *iLoader User's Manual.*  
+    
 -   ILOADER_ERRORS  
     ILOADER_ERRORS = *count* (Default: 50)  
     This property specifies the number of allowable maximum errors when uploading data with iLoader. The default value of this property is set to 50, and the upload is continuously executed regardless of the number of incurring errors if the default value is set to 0.
+    
 -   ILOADER_ARRAY  
     ILOADER_ARRAY = *count* (Default: 1)  
     This property specifies the number of rows to be processed at once when downloading or uploading data with iLoader.
+    
 -   ILOADER**\_**COMMIT  
     ILOADER**\_**COMMIT = *count* (Default: 1000)  
     This property specifies the unit(number) to commit when uploading the data with iLoader. The value of -commit option can be specified as well.
+    
 -   ILOADER_PARALLEL  
     ILOADER_PARALLEL = *count* (Default: 1)  
     This property specifies the number of threads which will be executed with parallel processing when uploading or downloading with iLoader.
+    
 -   ILOADER_ASYNC_PREFETCH  
     ILOADER_ASYNC_PREFETCH = OFF\|ON\|AUTO (Default: OFF)  
     This property sets asynchronous prefect behavior when downloading data to iLoader. For more information, please refer to the '-async_prefetch' option in the *iLoader User's Manual.*
+    
 -   SSL_ENABLE  
     This property specifies whether to connect to the target database using the SSL protocol.  
     SSL_ENABLE = ON/OFF  
     If this property is set to ON, SSL-related options are enabled for iSQL and iLoader commands in the shell scripts (run_is.sh and run_il_in.sh) to be executed on the target database.  
     SSL-related options can be enabled with the SSL_CA, SSL_CAPATH, SSL_CERT, SSL_KEY, SSL_CIPHER, SSL_VERIFY properties. For further information about these properties, please refer to Parameters.
+    
+- ILOADER_GEOM
+
+  This property specifies the processing of spatial data in Well-Known Binary (WKB) format when downloading spatial data with WKB iLoader. The '-geom WKB' option is added to the run_il_out.sh file.
 
 
 

--- a/Manuals/Altibase_7.3/eng/iLoader User's Manual.md
+++ b/Manuals/Altibase_7.3/eng/iLoader User's Manual.md
@@ -408,7 +408,9 @@ iloader [-h]
         [-partition]
         [-dry-run]
         [-prefetch_rows]
-        [-async_prefetch off|on|auto]]
+        [-async_prefetch off|on|auto]
+        [-geom WKB]]
+        [-nologging]
 ```
 
 
@@ -459,6 +461,8 @@ iLoader is run with the following options. Where applicable, default values are 
 | \-split *n*                               | Specifies the number of records to copy to each file (only meaningful when used with the -out option). After the command is executed, multiple backup files, each storing a number of records equal to n and having the names datefile.dat0, datafile.dat1, etc... will have been created. |
 | \-errors *count*                          | This specifies the maximum number of allowable errors when iLoader is executed with the -in option. If the number of errors exceeds the number specified here, execution terminates. If this option is omitted, the default is 50. If this value is set to 0, execution continues regardless of the number of errors. The number of errors occurring during the uploading operation may exceed the number specified here. When this option is used in conjunction with the -parallel option, if the number of errors exceeds the specified value for one of multiple threads executing in parallel, all threads are terminated. |
 | \-partition                               | If the table specified using the -T option is a partitioned table, a number of FORM files equal to the number of partitions in the table will be generated. The name of each FORM file will have this structure: [formfile_name.partition_name]. If the specified table is not a partitioned table, one FORM file, named formfile_name, will be generated. |
+| -extra_col_delimiter                      | This is used to recognize the end of a record when column and record delimiters are consecutively positioned after the last column in a record. <br>For example, if a data file has a column delimiter '^' and a record delimiter '\n', and it has the following format, the -extra_col_delimiter option is required:<br> Kim^1077^RD^\n<br> Lee^1099^CS^\n<br>This can be used in conjunction with the -rule csv or -t option. |
+| -geom [WKB]                               | During the execution of the out mode, this option is used to output spatial data in Well-Known Binary (WKB) format.<br> It is utilized to migrate spatial data in Altibase, which supports the Extended Well-Known Binary (EWKB) format, to a lower version that uses the WKB format. If this option is not used, it follows Altibase's spatial object support format. |
 
 -   If the -S, -U and -P command-line options are omitted, the user will be prompted to enter the values of these options manually at the time of execution.
 
@@ -1376,6 +1380,9 @@ Usage : { in | out | formout | structout | help }
         [-partition]
         [-dry-run]
         [-prefetch_rows]
+        [-async_prefetch off|on|auto]
+        [-geom WKB]
+        [-lightmode]
 iLoader> help help
 Ex) help [ in | out | formout | structout | exit | help ]
 
@@ -1414,7 +1421,10 @@ $ iloader help
                      [-rule csv]
                      [-partition]
                      [-dry-run]
-                     [-prefetch_rows]]
+                     [-prefetch_rows]
+                     [-async_prefetch off|on|auto]
+                     [-geom WKB]
+                     [-lightmode]]
             -h            : This screen
             -s            : Specify server name to connect
             -u            : Specify user name to connect


### PR DESCRIPTION
-Spatial SQL Reference : 개요와 각 함수의 세부 변경사항 수정
- iLoader User's Manual: -geom WKB 옵션 관련 내용과 예제 수정. 이 과정에서(공간 함수와는 관련 없지만) 누락된 옵션인 -extra_col_delimiter도 같이 수정했고, 일부 수정 사항은 -lightmode 수정 사항인 BUG-50747과 범위가 겹침.(50747 작업 시 크게 충돌 날 것은 아닙니다만 혹시 몰라서 알립니다) 
- Utilities Manual - ILOADER_GEOM property 내용 추가