### PR TITLE
BUG-50827

### DIFF
--- a/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
@@ -1426,7 +1426,7 @@ Since Migration Center 7.11, if a table's column length of a source database exc
 
 |      | Source        | Destination     | Notice                                                       |
 | :--: | :------------ | :-------------- | :----------------------------------------------------------- |
-|  1   | BINARY        | BLOB            |                                                              |
+|  1   | BINARY        | BYTE            |                                                              |
 |  2   | BINARY_DOUBLE | DOUBLE          | Special values such as NaN (Not a Number) and INF (Infinity) are not supported by Altibase. So, these values are not migrated. |
 |  3   | BINARY_FLOAT  | FLOAT           |                                                              |
 |  4   | BLOB          | BLOB            |                                                              |

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -1511,7 +1511,7 @@ Migration Center 7.11부터 원본 데이터베이스의 문자형 데이터 타
 
 |      | 원본          | 대상              | 주의 사항                                                    |
 | :--: | :------------ | :---------------- | :----------------------------------------------------------- |
-|  1   | BINARY        | BLOB              |                                                              |
+|  1   | BINARY        | BYTE              |                                                              |
 |  2   | BINARY_DOUBLE | DOUBLE            | Altibase는 특수한 값인 NaN (Not a Number)과 INF (Infinity)를 지원하지 않기 때문에, 이 값들은 마이그레이션 되지 않는다. |
 |  3   | BINARY_FLOAT  | FLOAT             |                                                              |
 |  4   | BLOB          | BLOB              |                                                              |


### PR DESCRIPTION
INC-48639 [네이블/SBC] TimeSten WIn-Back에서 제안된 내용으로 파생된 버그입니다.
기존 Migration Center TimesTen Binary 타입의 Altibase 기본 매핑 타입은 Altibase BLOB이었으나, 해당 인시던트에서 Altibase Byte 타입으로 변경을 요청받았습니다.

TimesTen Binary 타입의 최대 크기는 8300바이트, Altibase Byte 최대 크기는 32000바이트이고, 두 타입 모두 컬럼 길이보다 짧은 길이 값 입력 시 컬럼 길이만큼 오른쪽에 '0'으로 채워집니다.
변경 전 마이그레이션 사전 수행 테스트 결과 매핑 타입을 Byte로 변경하더라도 문제 없이 잘 수행되었습니다.

- 원인 : 기존 TimesTen Binary 타입 기본 매핑 타입은 BLOB으로 매핑하도록 되어 있으나, Altibase Byte 타입으로 매핑하더라도 문제가 없을 것이라 예상되어 변경 전 검증이 필요합니다.
- 해결 : TimesTen Binary 타입을 Altibase Byte 타입으로 매핑하여 마이그레이션 수행 테스트 결과 데이터 손실이 발생하지 않아 매핑이 가능함을 확인하였고, REVIEW-14783을 통해 최종 반영 여부를 결정하였습니다.

해당 내용 매뉴얼 반영을 위해 매뉴얼 수정이 필요합니다.

