### PR TITLE
BUG-51687 Migration Center BUG-51650 처리에 따른 매뉴얼 업데이트

### DIFF
--- a/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/eng/Migration Center User's Manual.md
@@ -1467,7 +1467,7 @@ For large tables, the length of data storage in the target database can be much 
 
 #### Support Character Set for Each Database
 
-For character sets not listed in the table below, Migration Center does not perform length correction.
+For character sets not listed in the table below, Migration Center considers MaxBytes as 1.
 
 ##### Altibase
 
@@ -1482,6 +1482,7 @@ For character sets not listed in the table below, Migration Center does not perf
 | SHIFTJIS      | 2                        |
 | MS932         | 2                        |
 | EUCJP         | 3                        |
+| ASCII         | 1                        |
 
 ##### Cubrid
 
@@ -1529,19 +1530,173 @@ SELECT CHARACTER_SET_NAME,MAXLEN FROM INFORMATION_SCHEMA.CHARACTER_SETS;
 
 ##### Oracle
 
-| Character Set | Max. Bytes Per Character |
-| ------------- | ------------------------ |
-| AL32UTF8      | 4                        |
-| JA16EUC       | 3                        |
-| JA16EUCTILDE  | 3                        |
-| JA16SJIS      | 2                        |
-| JA16SJISTILDE | 2                        |
-| KO16MSWIN949  | 2                        |
-| UTF8          | 3                        |
-| ZHS16GBK      | 2                        |
-| ZHT16HKSCS    | 2                        |
-| ZHT16MSWIN950 | 2                        |
-| ZHT32EUC      | 4                        |
+| Character Set   | Max. Bytes Per Character |
+| --------------- | ------------------------ |
+| AL32UTF8        | 4                        |
+| JA16EUC         | 3                        |
+| JA16EUCTILDE    | 3                        |
+| JA16SJIS        | 2                        |
+| JA16SJISTILDE   | 2                        |
+| KO16MSWIN949    | 2                        |
+| UTF8            | 3                        |
+| ZHS16GBK        | 2                        |
+| ZHT16HKSCS      | 2                        |
+| ZHT16MSWIN950   | 2                        |
+| ZHT32EUC        | 4                        |
+| ZHT16HKSCS31    | 2                        |
+| US7ASCII        | 1                        |
+| BG8PC437S       | 1                        |
+| BLT8PC775       | 1                        |
+| CON8PC863       | 1                        |
+| EE8PC852        | 1                        |
+| EL8EBCDIC423R   | 1                        |
+| EL8PC437S       | 1                        |
+| EL8PC851        | 1                        |
+| EL8PC869        | 1                        |
+| IS8PC861        | 1                        |
+| IW8PC1507       | 1                        |
+| LT8PC772        | 1                        |
+| LT8PC774        | 1                        |
+| LV8PC8LR        | 1                        |
+| LV8PC1117       | 1                        |
+| LV8RST104090    | 1                        |
+| N8PC865         | 1                        |
+| RU8PC855        | 1                        |
+| RU8PC866        | 1                        |
+| TR8PC857        | 1                        |
+| US8PC437        | 1                        |
+| WE8PC850        | 1                        |
+| WE8PC858        | 1                        |
+| WE8PC860        | 1                        |
+| AR8ARABICMACS   | 1                        |
+| CL8MACCVRILLICS | 1                        |
+| EE8MACCES       | 1                        |
+| EE8MACCROATIANS | 1                        |
+| EL8MACGREEKS    | 1                        |
+| IW8MACHEBREWS   | 1                        |
+| TH8MACTHAIS     | 1                        |
+| TH8MACTURKISHS  | 1                        |
+| WE8MACROMAN8S   | 1                        |
+| AR8MSWIN1256    | 1                        |
+| BG8MSWIN        | 1                        |
+| BLT8MSWIN1257   | 1                        |
+| CL8MSWIN1251    | 1                        |
+| EE8MSWIN1250    | 1                        |
+| EL8MSWIN1253    | 1                        |
+| ET8MSWIN923     | 1                        |
+| IW8MSWIN1255    | 1                        |
+| LT8MSWIN921     | 1                        |
+| TR8MSWIN1254    | 1                        |
+| VN8MSWIN1258    | 1                        |
+| WE8MSWIN1252    | 1                        |
+| AR8ADOS710      | 1                        |
+| AR8ADOS720      | 1                        |
+| AR8APTEC715     | 1                        |
+| AR8ASMO8X       | 1                        |
+| AR8EBCDICX      | 1                        |
+| AR8EBCDIC420S   | 1                        |
+| AR8ISO8859P6    | 1                        |
+| AR8MUSSAD768    | 1                        |
+| AR8NAFITHA711   | 1                        |
+| AR8NAFITHA721   | 1                        |
+| AR8SAKHR706     | 1                        |
+| AR8SAKHR707     | 1                        |
+| AZ8ISO8859P9E   | 1                        |
+| BLT8CP921       | 1                        |
+| BLT8EBCDIC1112  | 1                        |
+| BLT8EBCDIC1112S | 1                        |
+| BLT8ISO8859P13  | 1                        |
+| BN8BSCII        | 1                        |
+| CE8BS2000       | 1                        |
+| CEL8ISO8859P14  | 1                        |
+| CL8BS2000       | 1                        |
+| CL8EBCDIC1025   | 1                        |
+| CL8EBCDIC1025C  | 1                        |
+| CL8EBCDIC1025R  | 1                        |
+| CL8EBCDIC1025S  | 1                        |
+| CL8EBCDIC1025X  | 1                        |
+| CL8EBCDIC1158   | 1                        |
+| CL8EBCDIC1158R  | 1                        |
+| CL8ISO8859P5    | 1                        |
+| CL8ISOIR111     | 1                        |
+| CL8KOI8R        | 1                        |
+| CL8KOI8U        | 1                        |
+| D8BS2000        | 1                        |
+| D8EBCDIC273     | 1                        |
+| D8EBCDIC1141    | 1                        |
+| DK8BS2000       | 1                        |
+| DK8EBCDIC277    | 1                        |
+| DK8EBCDIC1142   | 1                        |
+| E8BS2000        | 1                        |
+| EE8BS2000       | 1                        |
+| EE8EBCDIC870    | 1                        |
+| EE8EBCDIC870C   | 1                        |
+| EE8EBCDIC870S   | 1                        |
+| EE8ISO8859P2    | 1                        |
+| EL8DEC          | 1                        |
+| EL8EBCDIC875    | 1                        |
+| EL8EBCDIC875R   | 1                        |
+| EL8GCOS7        | 1                        |
+| EL8ISO8859P7    | 1                        |
+| F8BS2000        | 1                        |
+| F8EBCDIC297     | 1                        |
+| F8EBCDIC1147    | 1                        |
+| HU8ABMOD        | 1                        |
+| HU8CWI2         | 1                        |
+| I8EBCDIC280     | 1                        |
+| I8EBCDIC1144    | 1                        |
+| IN8ISCII        | 1                        |
+| IW8EBCDIC424    | 1                        |
+| IW8EBCDIC424S   | 1                        |
+| IW8EBCDIC1086   | 1                        |
+| IW8ISO8859P8    | 1                        |
+| LA8ISO6937      | 1                        |
+| LA8PASSPORT     | 1                        |
+| NE8ISO8859P10   | 1                        |
+| NEE8ISO8859P4   | 1                        |
+| RU8BESTA        | 1                        |
+| S8BS2000        | 1                        |
+| S8EBCDIC278     | 1                        |
+| S8EBCDIC1143    | 1                        |
+| SE8ISO8859P3    | 1                        |
+| TH8TISEBCDIC    | 1                        |
+| TH8TISEBCDICS   | 1                        |
+| TH8TISASCII     | 1                        |
+| TR8DEC          | 1                        |
+| TR8EBCDIC1026   | 1                        |
+| TR8EBCDIC1026S  | 1                        |
+| US8BS2000       | 1                        |
+| US8ICL          | 1                        |
+| VN8VN3          | 1                        |
+| WE8BS2000       | 1                        |
+| WE8BS2000E      | 1                        |
+| WE8BS2000L5     | 1                        |
+| WE8DEC          | 1                        |
+| WE8DG           | 1                        |
+| WE8EBCDIC37     | 1                        |
+| WE8EBCDIC37C    | 1                        |
+| WE8EBCDIC284    | 1                        |
+| WE8EBCDIC285    | 1                        |
+| WE8EBCDIC500    | 1                        |
+| WE8EBCDIC500C   | 1                        |
+| WE8EBCDIC871    | 1                        |
+| WE8EBCDIC924    | 1                        |
+| WE8EBCDIC1047   | 1                        |
+| WE8EBCDIC1047E  | 1                        |
+| WE8EBCDIC1140   | 1                        |
+| WE8EBCDIC1140C  | 1                        |
+| WE8EBCDIC1145   | 1                        |
+| WE8EBCDIC1146   | 1                        |
+| WE8EBCDIC1148   | 1                        |
+| WE8EBCDIC1148C  | 1                        |
+| WE8GCOS7        | 1                        |
+| WE8ICL          | 1                        |
+| WE8ISO8859P1    | 1                        |
+| WE8ISO8859P9    | 1                        |
+| WE8ISO8859P15   | 1                        |
+| WE8NCR4970      | 1                        |
+| WE8NEXTSTEP     | 1                        |
+| WE8ROMAN8       | 1                        |
 
 ##### Tibero
 
@@ -1557,6 +1712,29 @@ SELECT CHARACTER_SET_NAME,MAXLEN FROM INFORMATION_SCHEMA.CHARACTER_SETS;
 | JA16EUCTILDE  | 3                        |
 | GBK           | 2                        |
 | ZHT16HKSCS    | 2                        |
+| EUCTW         | 4                        |
+| GB18030       | 4                        |
+| UTF16         | 4                        |
+| SJISTILDE     | 2                        |
+| ZHT16BIG5     | 2                        |
+| ZHT16MSWIN950 | 2                        |
+| ASCII         | 1                        |
+| VN8VN3        | 1                        |
+| TH8TISASCII   | 1                        |
+| EE8ISO8859P2  | 1                        |
+| WE8MSWIN1252  | 1                        |
+| WE8ISO8859P1  | 1                        |
+| WE8ISO8859P9  | 1                        |
+| WE8ISO8859P15 | 1                        |
+| CL8MSWIN1251  | 1                        |
+| CL8KOI8R      | 1                        |
+| CL8ISO8859P5  | 1                        |
+| RU8PC866      | 1                        |
+| EL8ISO8859P7  | 1                        |
+| EL8MSWIN1253  | 1                        |
+| AR8ISO8859P6  | 1                        |
+| AR8MSWIN1256  | 1                        |
+| IW8ISO8859P8  | 1                        |
 
 ##### TimesTen
 

--- a/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
+++ b/Manuals/Tools/Altibase_trunk/kor/Migration Center User's Manual.md
@@ -1473,7 +1473,7 @@ Correction Factor = Dest. MaxBytes / Src. MaxBytes
 
 #### 데이터베이스별 지원 문자 집합
 
-아래 표에 없는 문자 집합의 경우에는 Migration Center가 길이 보정을 하지 않는다.
+아래 표에 없는 문자 집합의 경우에는 Migration Center가 MaxBytes를 1로 간주한다.
 
 ##### Altibase
 
@@ -1488,6 +1488,7 @@ Correction Factor = Dest. MaxBytes / Src. MaxBytes
 | SHIFTJIS      | 2                        |
 | MS932         | 2                        |
 | EUCJP         | 3                        |
+| ASCII         | 1                        |
 
 ##### Cubrid
 
@@ -1535,19 +1536,173 @@ SELECT CHARACTER_SET_NAME,MAXLEN FROM INFORMATION_SCHEMA.CHARACTER_SETS;
 
 ##### Oracle
 
-| Character Set | Max. Bytes Per Character |
-| ------------- | ------------------------ |
-| AL32UTF8      | 4                        |
-| JA16EUC       | 3                        |
-| JA16EUCTILDE  | 3                        |
-| JA16SJIS      | 2                        |
-| JA16SJISTILDE | 2                        |
-| KO16MSWIN949  | 2                        |
-| UTF8          | 3                        |
-| ZHS16GBK      | 2                        |
-| ZHT16HKSCS    | 2                        |
-| ZHT16MSWIN950 | 2                        |
-| ZHT32EUC      | 4                        |
+| Character Set   | Max. Bytes Per Character |
+| --------------- | ------------------------ |
+| AL32UTF8        | 4                        |
+| JA16EUC         | 3                        |
+| JA16EUCTILDE    | 3                        |
+| JA16SJIS        | 2                        |
+| JA16SJISTILDE   | 2                        |
+| KO16MSWIN949    | 2                        |
+| UTF8            | 3                        |
+| ZHS16GBK        | 2                        |
+| ZHT16HKSCS      | 2                        |
+| ZHT16MSWIN950   | 2                        |
+| ZHT32EUC        | 4                        |
+| ZHT16HKSCS31    | 2                        |
+| US7ASCII        | 1                        |
+| BG8PC437S       | 1                        |
+| BLT8PC775       | 1                        |
+| CON8PC863       | 1                        |
+| EE8PC852        | 1                        |
+| EL8EBCDIC423R   | 1                        |
+| EL8PC437S       | 1                        |
+| EL8PC851        | 1                        |
+| EL8PC869        | 1                        |
+| IS8PC861        | 1                        |
+| IW8PC1507       | 1                        |
+| LT8PC772        | 1                        |
+| LT8PC774        | 1                        |
+| LV8PC8LR        | 1                        |
+| LV8PC1117       | 1                        |
+| LV8RST104090    | 1                        |
+| N8PC865         | 1                        |
+| RU8PC855        | 1                        |
+| RU8PC866        | 1                        |
+| TR8PC857        | 1                        |
+| US8PC437        | 1                        |
+| WE8PC850        | 1                        |
+| WE8PC858        | 1                        |
+| WE8PC860        | 1                        |
+| AR8ARABICMACS   | 1                        |
+| CL8MACCVRILLICS | 1                        |
+| EE8MACCES       | 1                        |
+| EE8MACCROATIANS | 1                        |
+| EL8MACGREEKS    | 1                        |
+| IW8MACHEBREWS   | 1                        |
+| TH8MACTHAIS     | 1                        |
+| TH8MACTURKISHS  | 1                        |
+| WE8MACROMAN8S   | 1                        |
+| AR8MSWIN1256    | 1                        |
+| BG8MSWIN        | 1                        |
+| BLT8MSWIN1257   | 1                        |
+| CL8MSWIN1251    | 1                        |
+| EE8MSWIN1250    | 1                        |
+| EL8MSWIN1253    | 1                        |
+| ET8MSWIN923     | 1                        |
+| IW8MSWIN1255    | 1                        |
+| LT8MSWIN921     | 1                        |
+| TR8MSWIN1254    | 1                        |
+| VN8MSWIN1258    | 1                        |
+| WE8MSWIN1252    | 1                        |
+| AR8ADOS710      | 1                        |
+| AR8ADOS720      | 1                        |
+| AR8APTEC715     | 1                        |
+| AR8ASMO8X       | 1                        |
+| AR8EBCDICX      | 1                        |
+| AR8EBCDIC420S   | 1                        |
+| AR8ISO8859P6    | 1                        |
+| AR8MUSSAD768    | 1                        |
+| AR8NAFITHA711   | 1                        |
+| AR8NAFITHA721   | 1                        |
+| AR8SAKHR706     | 1                        |
+| AR8SAKHR707     | 1                        |
+| AZ8ISO8859P9E   | 1                        |
+| BLT8CP921       | 1                        |
+| BLT8EBCDIC1112  | 1                        |
+| BLT8EBCDIC1112S | 1                        |
+| BLT8ISO8859P13  | 1                        |
+| BN8BSCII        | 1                        |
+| CE8BS2000       | 1                        |
+| CEL8ISO8859P14  | 1                        |
+| CL8BS2000       | 1                        |
+| CL8EBCDIC1025   | 1                        |
+| CL8EBCDIC1025C  | 1                        |
+| CL8EBCDIC1025R  | 1                        |
+| CL8EBCDIC1025S  | 1                        |
+| CL8EBCDIC1025X  | 1                        |
+| CL8EBCDIC1158   | 1                        |
+| CL8EBCDIC1158R  | 1                        |
+| CL8ISO8859P5    | 1                        |
+| CL8ISOIR111     | 1                        |
+| CL8KOI8R        | 1                        |
+| CL8KOI8U        | 1                        |
+| D8BS2000        | 1                        |
+| D8EBCDIC273     | 1                        |
+| D8EBCDIC1141    | 1                        |
+| DK8BS2000       | 1                        |
+| DK8EBCDIC277    | 1                        |
+| DK8EBCDIC1142   | 1                        |
+| E8BS2000        | 1                        |
+| EE8BS2000       | 1                        |
+| EE8EBCDIC870    | 1                        |
+| EE8EBCDIC870C   | 1                        |
+| EE8EBCDIC870S   | 1                        |
+| EE8ISO8859P2    | 1                        |
+| EL8DEC          | 1                        |
+| EL8EBCDIC875    | 1                        |
+| EL8EBCDIC875R   | 1                        |
+| EL8GCOS7        | 1                        |
+| EL8ISO8859P7    | 1                        |
+| F8BS2000        | 1                        |
+| F8EBCDIC297     | 1                        |
+| F8EBCDIC1147    | 1                        |
+| HU8ABMOD        | 1                        |
+| HU8CWI2         | 1                        |
+| I8EBCDIC280     | 1                        |
+| I8EBCDIC1144    | 1                        |
+| IN8ISCII        | 1                        |
+| IW8EBCDIC424    | 1                        |
+| IW8EBCDIC424S   | 1                        |
+| IW8EBCDIC1086   | 1                        |
+| IW8ISO8859P8    | 1                        |
+| LA8ISO6937      | 1                        |
+| LA8PASSPORT     | 1                        |
+| NE8ISO8859P10   | 1                        |
+| NEE8ISO8859P4   | 1                        |
+| RU8BESTA        | 1                        |
+| S8BS2000        | 1                        |
+| S8EBCDIC278     | 1                        |
+| S8EBCDIC1143    | 1                        |
+| SE8ISO8859P3    | 1                        |
+| TH8TISEBCDIC    | 1                        |
+| TH8TISEBCDICS   | 1                        |
+| TH8TISASCII     | 1                        |
+| TR8DEC          | 1                        |
+| TR8EBCDIC1026   | 1                        |
+| TR8EBCDIC1026S  | 1                        |
+| US8BS2000       | 1                        |
+| US8ICL          | 1                        |
+| VN8VN3          | 1                        |
+| WE8BS2000       | 1                        |
+| WE8BS2000E      | 1                        |
+| WE8BS2000L5     | 1                        |
+| WE8DEC          | 1                        |
+| WE8DG           | 1                        |
+| WE8EBCDIC37     | 1                        |
+| WE8EBCDIC37C    | 1                        |
+| WE8EBCDIC284    | 1                        |
+| WE8EBCDIC285    | 1                        |
+| WE8EBCDIC500    | 1                        |
+| WE8EBCDIC500C   | 1                        |
+| WE8EBCDIC871    | 1                        |
+| WE8EBCDIC924    | 1                        |
+| WE8EBCDIC1047   | 1                        |
+| WE8EBCDIC1047E  | 1                        |
+| WE8EBCDIC1140   | 1                        |
+| WE8EBCDIC1140C  | 1                        |
+| WE8EBCDIC1145   | 1                        |
+| WE8EBCDIC1146   | 1                        |
+| WE8EBCDIC1148   | 1                        |
+| WE8EBCDIC1148C  | 1                        |
+| WE8GCOS7        | 1                        |
+| WE8ICL          | 1                        |
+| WE8ISO8859P1    | 1                        |
+| WE8ISO8859P9    | 1                        |
+| WE8ISO8859P15   | 1                        |
+| WE8NCR4970      | 1                        |
+| WE8NEXTSTEP     | 1                        |
+| WE8ROMAN8       | 1                        |
 
 ##### Tibero
 
@@ -1563,6 +1718,29 @@ SELECT CHARACTER_SET_NAME,MAXLEN FROM INFORMATION_SCHEMA.CHARACTER_SETS;
 | JA16EUCTILDE  | 3                        |
 | GBK           | 2                        |
 | ZHT16HKSCS    | 2                        |
+| EUCTW         | 4                        |
+| GB18030       | 4                        |
+| UTF16         | 4                        |
+| SJISTILDE     | 2                        |
+| ZHT16BIG5     | 2                        |
+| ZHT16MSWIN950 | 2                        |
+| ASCII         | 1                        |
+| VN8VN3        | 1                        |
+| TH8TISASCII   | 1                        |
+| EE8ISO8859P2  | 1                        |
+| WE8MSWIN1252  | 1                        |
+| WE8ISO8859P1  | 1                        |
+| WE8ISO8859P9  | 1                        |
+| WE8ISO8859P15 | 1                        |
+| CL8MSWIN1251  | 1                        |
+| CL8KOI8R      | 1                        |
+| CL8ISO8859P5  | 1                        |
+| RU8PC866      | 1                        |
+| EL8ISO8859P7  | 1                        |
+| EL8MSWIN1253  | 1                        |
+| AR8ISO8859P6  | 1                        |
+| AR8MSWIN1256  | 1                        |
+| IW8ISO8859P8  | 1                        |
 
 ##### TimesTen
 


### PR DESCRIPTION
BUG-51650 TH8TISASCII 문자 데이터 이관 중 invalid data type length가 발생합니다. 버그 처리에 따른 매뉴얼 수정 초안입니다.

Migration Center에서 이종 문자 집합을 고려한 문자형 칼럼 길이 자동 보정은 SrcDB와 DestDB 문자 집합의 한 문자 당 최대 바이트 수로 계산된 보정 계수(Correction Factor) 값으로 길이 보정이 수행됩니다.

기존에는 매뉴얼에 기재된 데이터베이스별 지원 문자 집합 표에 없는 즉, Migration Center가 인식하지 못하는 문자 집합의 경우 한 문자 당 최대 바이트 수를 1로 간주합니다. 또한 SrcDB 문자 집합 한 문자 당 최대 바이트 수가 1일 경우에는 칼럼 길이 자동 변환을 수행하지 않습니다.

1. SrcDB 문자 집합의 한 문자 당 최대 바이트 수가 1일 경우에도 칼럼 길이 자동 변환이 수행되도록 변경하였습니다.
2. 매뉴얼에 누락된 Oracle, Altibase, Tibero 지원 문자 집합 정보를 Migration Center에 추가하였습니다.

추가된 DB별 문자 집합 목록은 아래 링크를 참조하였습니다.
Oracle - [https://docs.oracle.com/en/database/oracle/oracle-database/21/nlspg/appendix-A-locale-data.html?utm_source=chatgpt.com#GUID-635EE39D-240E-4594-A253-76F7827DFEBF](https://docs.oracle.com/en/database/oracle/oracle-database/21/nlspg/appendix-A-locale-data.html?utm_source=chatgpt.com#GUID-635EE39D-240E-4594-A253-76F7827DFEBF)
Tibero - [https://docs.tmaxtibero.com/tibero/topics/installation/database-installation-on-linux/for-all/appendix/supported-character-sets](https://docs.tmaxtibero.com/tibero/topics/installation/database-installation-on-linux/for-all/appendix/supported-character-sets)